### PR TITLE
[Flaredown/FlaredownIOS-Web#2] store session in the cookie

### DIFF
--- a/frontend/app/session-stores/application.js
+++ b/frontend/app/session-stores/application.js
@@ -1,0 +1,5 @@
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+
+export default CookieStore.extend({
+  cookieExpirationTime: 32000000,
+});

--- a/frontend/app/session-stores/application.js
+++ b/frontend/app/session-stores/application.js
@@ -1,5 +1,5 @@
 import CookieStore from 'ember-simple-auth/session-stores/cookie';
 
 export default CookieStore.extend({
-  cookieExpirationTime: 32000000,
+  cookieExpirationTime: 2147483647,
 });


### PR DESCRIPTION
@lmerriam I have failed to spot the bug in iOS simulator, so I set the session store to use cookie explicitly instead of adaptive storage.

This will trigger one time relogin after deploy.

Should we put it on production?