### PR TITLE
remove last usages of airbrake

### DIFF
--- a/frontend/app/routes/application.js
+++ b/frontend/app/routes/application.js
@@ -11,7 +11,6 @@ const {
 
 export default Route.extend(ApplicationRouteMixin, {
   notifications: service(),
-  airbrake: service(),
   session: service(),
 
   beforeModel() {
@@ -21,14 +20,7 @@ export default Route.extend(ApplicationRouteMixin, {
   sessionAuthenticated() {
     this._super(...arguments);
 
-    get(this, 'airbrake').setSession({ data: get(this, 'session.data.authenticated') });
     get(this, 'notifications').loadNotifications();
-  },
-
-  sessionInvalidated() {
-    this._super(...arguments);
-
-    get(this, 'airbrake').setSession({ message: 'Unauthorized user' });
   },
 
   actions: {

--- a/frontend/config/environment.js
+++ b/frontend/config/environment.js
@@ -87,12 +87,6 @@ module.exports = function(environment) {
 
     ENV.apiHost = process.env.API_HOST;
     var STATIC_URL = process.env.STATIC_URL;
-
-    ENV.airbrake = {
-      host: process.env.AIRBRAKE_HOST,
-      projectId: process.env.AIRBRAKE_PROJECT_ID,
-      projectKey: process.env.AIRBRAKE_PROJECT_KEY,
-    }
   }
 
   ENV.staticUrl = STATIC_URL;


### PR DESCRIPTION
Now testing staging I was getting an error after login: 

```
TypeError: Cannot read properties of undefined (reading 'setSession')
```

This was because we were trying to inject the airbrake service that we have removed in a previous PR. 

We can always add this back in at some point in the future but for now this PR is required to fix the issue with staging 👍 