### PR TITLE
Begin system spec harness

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ desc "run application"
 task :run do
   pids = [
     spawn("cd backend && bundle install && foreman start -f Procfile.local"),
-    spawn("cd frontend && rm -rfd ./dist && ./node_modules/.bin/ember serve --port 4300 --proxy http://localhost:3000")
+    spawn("cd frontend && rm -rfd ./dist && ./node_modules/.bin/ember serve --port 4300")
   ]
 
   trap "INT" do

--- a/backend/.rspec
+++ b/backend/.rspec
@@ -1,1 +1,2 @@
 --color
+--tag ~type:system

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -90,6 +90,8 @@ group :development do
 end
 
 group :test do
+  gem "capybara"
+  gem "cuprite"
   gem "mongoid-rspec"
   gem "shoulda-matchers"
   gem "vcr"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -97,6 +97,15 @@ GEM
     cancancan (3.3.0)
     cancancan-mongoid (2.0.0)
       cancancan (>= 2.0, < 4)
+    capybara (3.39.2)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -109,6 +118,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    cuprite (0.14.3)
+      capybara (~> 3.0)
+      ferrum (~> 0.13.0)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -170,6 +182,11 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    ferrum (0.13)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (>= 0.6, < 0.8)
     ffaker (2.21.0)
     ffi (1.15.5-java)
     forecast_io (2.0.2)
@@ -213,6 +230,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.4)
@@ -446,11 +464,14 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.6-java)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     yard (0.9.34)
     zeitwerk (2.6.9)
 
@@ -471,8 +492,10 @@ DEPENDENCIES
   byebug
   cancancan (~> 3.3.0)
   cancancan-mongoid (= 2.0.0)
+  capybara
   colored (~> 1.2)
   countries
+  cuprite
   database_cleaner
   database_cleaner-mongoid
   devise (= 4.8.0)

--- a/backend/bin/system_spec
+++ b/backend/bin/system_spec
@@ -1,0 +1,4 @@
+# Eg:
+#   bin/system_spec
+#   bin/system_spec --format doc spec/system/signup_spec.rb
+bundle exec rspec --tag type:system "$@"

--- a/backend/env-example
+++ b/backend/env-example
@@ -55,3 +55,10 @@ FULLSTORY_ORG=
 
 # MongoDB
 MONGODB_HOST=localhost
+
+# System spec server ports
+SYSTEM_SPEC_BACKEND_PORT=3003
+SYSTEM_SPEC_FRONTEND_PORT=4303
+
+# Run system specs with a headless chrome instance
+HEADLESS_CHROME=true

--- a/backend/lib/tasks/spec.rake
+++ b/backend/lib/tasks/spec.rake
@@ -1,0 +1,17 @@
+require_relative "../../spec/system/support/frontend_app"
+
+namespace :spec do
+  namespace :system do
+    task :start_frontend do
+      frontend_app = SystemSpec::FrontendApp.instance
+      frontend_app.start $stdout
+
+      trap "INT" do
+        frontend_app.stop
+        exit 1
+      end
+
+      frontend_app.wait_on
+    end
+  end
+end

--- a/backend/lib/tasks/spec.rake
+++ b/backend/lib/tasks/spec.rake
@@ -1,8 +1,19 @@
-require_relative "../../spec/system/support/frontend_app"
-
 namespace :spec do
+  begin
+    require "rspec/core/rake_task"
+
+    Rake::Task[:system].clear
+    RSpec::Core::RakeTask.new(:system) do |t|
+      t.rspec_opts = "--tag type:system"
+    end
+  rescue LoadError
+    # no rspec available
+  end
+
   namespace :system do
     task :start_frontend do
+      require_relative "../../spec/system/support/frontend_app"
+
       frontend_app = SystemSpec::FrontendApp.instance
       frontend_app.start $stdout
 

--- a/backend/spec/system/signup_spec.rb
+++ b/backend/spec/system/signup_spec.rb
@@ -1,8 +1,8 @@
 require "system_spec_helper"
 
 RSpec.describe "signup flow" do
-  pending "works" do
+  it "loads the root page" do
     visit "/"
-    expect(page.title).to eq "not this"
+    expect(page.title).to eq "Flaredown"
   end
 end

--- a/backend/spec/system/signup_spec.rb
+++ b/backend/spec/system/signup_spec.rb
@@ -1,0 +1,8 @@
+require "system_spec_helper"
+
+RSpec.describe "signup flow" do
+  pending "works" do
+    visit "/"
+    expect(page.title).to eq "not this"
+  end
+end

--- a/backend/spec/system/support/capybara_config.rb
+++ b/backend/spec/system/support/capybara_config.rb
@@ -16,4 +16,4 @@ Capybara.save_path = ENV.fetch("CAPYBARA_ARTIFACTS", "./tmp/capybara")
 Capybara.server_port = ENV["SYSTEM_SPEC_BACKEND_PORT"]
 
 # Where to find frontend app; see ./frontend_app.rb
-Capybara.app_host = "http://localhost:#{ENV['SYSTEM_SPEC_FRONTEND_PORT']}"
+Capybara.app_host = "http://localhost:#{ENV["SYSTEM_SPEC_FRONTEND_PORT"]}"

--- a/backend/spec/system/support/capybara_config.rb
+++ b/backend/spec/system/support/capybara_config.rb
@@ -1,19 +1,23 @@
-# Usually, especially when using Selenium, developers tend to increase the max wait time.
-# With Cuprite, there is no need for that.
-# We use a Capybara default value here explicitly.
-Capybara.default_max_wait_time = 2
+# Most of the config here, and in cuprite_config, was borrowed, with many thanks, from:
+# https://evilmartians.com/chronicles/system-of-a-test-setting-up-end-to-end-rails-testing
+Capybara.configure do |config|
+  # Usually, especially when using Selenium, developers tend to increase the max wait time.
+  # With Cuprite, there is no need for that.
+  # We use a Capybara default value here explicitly.
+  config.default_max_wait_time = 2
 
-# Normalize whitespaces when using `has_text?` and similar matchers,
-# i.e., ignore newlines, trailing spaces, etc.
-# That makes tests less dependent on slightly UI changes.
-Capybara.default_normalize_ws = true
+  # Normalize whitespaces when using `has_text?` and similar matchers,
+  # i.e., ignore newlines, trailing spaces, etc.
+  # That makes tests less dependent on slightly UI changes.
+  config.default_normalize_ws = true
 
-# Where to store system tests artifacts (e.g. screenshots, downloaded files, etc.).
-# It could be useful to be able to configure this path from the outside (e.g., on CI).
-Capybara.save_path = ENV.fetch("CAPYBARA_ARTIFACTS", "./tmp/capybara")
+  # Where to store system tests artifacts (e.g. screenshots, downloaded files, etc.).
+  # It could be useful to be able to configure this path from the outside (e.g., on CI).
+  config.save_path = ENV.fetch("CAPYBARA_ARTIFACTS", "./tmp/capybara")
 
-# Port on which to fire up the rails backend.
-Capybara.server_port = ENV["SYSTEM_SPEC_BACKEND_PORT"]
+  # Port on which to fire up the rails backend.
+  config.server_port = ENV["SYSTEM_SPEC_BACKEND_PORT"]
 
-# Where to find frontend app; see ./frontend_app.rb
-Capybara.app_host = "http://localhost:#{ENV["SYSTEM_SPEC_FRONTEND_PORT"]}"
+  # Where to find frontend app; see ./frontend_app.rb
+  config.app_host = "http://localhost:#{ENV["SYSTEM_SPEC_FRONTEND_PORT"]}"
+end

--- a/backend/spec/system/support/capybara_config.rb
+++ b/backend/spec/system/support/capybara_config.rb
@@ -1,0 +1,13 @@
+# Usually, especially when using Selenium, developers tend to increase the max wait time.
+# With Cuprite, there is no need for that.
+# We use a Capybara default value here explicitly.
+Capybara.default_max_wait_time = 2
+
+# Normalize whitespaces when using `has_text?` and similar matchers,
+# i.e., ignore newlines, trailing spaces, etc.
+# That makes tests less dependent on slightly UI changes.
+Capybara.default_normalize_ws = true
+
+# Where to store system tests artifacts (e.g. screenshots, downloaded files, etc.).
+# It could be useful to be able to configure this path from the outside (e.g., on CI).
+Capybara.save_path = ENV.fetch("CAPYBARA_ARTIFACTS", "./tmp/capybara")

--- a/backend/spec/system/support/capybara_config.rb
+++ b/backend/spec/system/support/capybara_config.rb
@@ -11,3 +11,9 @@ Capybara.default_normalize_ws = true
 # Where to store system tests artifacts (e.g. screenshots, downloaded files, etc.).
 # It could be useful to be able to configure this path from the outside (e.g., on CI).
 Capybara.save_path = ENV.fetch("CAPYBARA_ARTIFACTS", "./tmp/capybara")
+
+# Port on which to fire up the rails backend.
+Capybara.server_port = ENV["SYSTEM_SPEC_BACKEND_PORT"]
+
+# Where to find frontend app; see ./frontend_app.rb
+Capybara.app_host = "http://localhost:#{ENV['SYSTEM_SPEC_FRONTEND_PORT']}"

--- a/backend/spec/system/support/cuprite_config.rb
+++ b/backend/spec/system/support/cuprite_config.rb
@@ -1,0 +1,22 @@
+# First, load Cuprite Capybara integration
+require "capybara/cuprite"
+
+# Then, we need to register our driver to be able to use it later
+# with #driven_by method.
+# NOTE: The name :cuprite is already registered by Rails.
+# See https://github.com/rubycdp/cuprite/issues/180
+Capybara.register_driver(:better_cuprite) do |app|
+  Capybara::Cuprite::Driver.new(
+    app,
+    **{ # TODO: just inline?
+      window_size:     [1200, 800],
+      browser_options: {},
+      process_timeout: 10,
+      inspector:       true,
+      headless:        ENV["HEADLESS_CHROME"] != "false"
+    }
+  )
+end
+
+# Configure Capybara to use :better_cuprite driver by default
+Capybara.default_driver = Capybara.javascript_driver = :better_cuprite

--- a/backend/spec/system/support/cuprite_config.rb
+++ b/backend/spec/system/support/cuprite_config.rb
@@ -8,11 +8,11 @@ require "capybara/cuprite"
 Capybara.register_driver(:better_cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
-    window_size:     [1200, 800],
+    window_size: [1200, 800],
     browser_options: {},
     process_timeout: 10,
-    inspector:       true,
-    headless:        ENV["HEADLESS_CHROME"] != "false"
+    inspector: true,
+    headless: ENV["HEADLESS_CHROME"] != "false"
   )
 end
 

--- a/backend/spec/system/support/cuprite_config.rb
+++ b/backend/spec/system/support/cuprite_config.rb
@@ -8,13 +8,11 @@ require "capybara/cuprite"
 Capybara.register_driver(:better_cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
-    **{ # TODO: just inline?
-      window_size:     [1200, 800],
-      browser_options: {},
-      process_timeout: 10,
-      inspector:       true,
-      headless:        ENV["HEADLESS_CHROME"] != "false"
-    }
+    window_size:     [1200, 800],
+    browser_options: {},
+    process_timeout: 10,
+    inspector:       true,
+    headless:        ENV["HEADLESS_CHROME"] != "false"
   )
 end
 

--- a/backend/spec/system/support/cuprite_config.rb
+++ b/backend/spec/system/support/cuprite_config.rb
@@ -1,11 +1,6 @@
-# First, load Cuprite Capybara integration
 require "capybara/cuprite"
 
-# Then, we need to register our driver to be able to use it later
-# with #driven_by method.
-# NOTE: The name :cuprite is already registered by Rails.
-# See https://github.com/rubycdp/cuprite/issues/180
-Capybara.register_driver(:better_cuprite) do |app|
+Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
     window_size: [1200, 800],
@@ -16,5 +11,4 @@ Capybara.register_driver(:better_cuprite) do |app|
   )
 end
 
-# Configure Capybara to use :better_cuprite driver by default
-Capybara.default_driver = Capybara.javascript_driver = :better_cuprite
+Capybara.default_driver = Capybara.javascript_driver = :cuprite

--- a/backend/spec/system/support/frontend_app.rb
+++ b/backend/spec/system/support/frontend_app.rb
@@ -53,12 +53,11 @@ module SystemSpec
 
     def frontend_app_cmd
       [
+        "PORT=#{backend_port}",
         "BASE_URL=#{frontend_app_url}",
         "FRONTEND_PORT=#{frontend_port}",
-        "PORT=#{backend_port}",
         "./node_modules/.bin/ember", "serve",
-        "--port", frontend_port,
-        "--proxy", "http://localhost:#{backend_port}"
+        "--port", frontend_port
       ].join(" ")
     end
 

--- a/backend/spec/system/support/frontend_app.rb
+++ b/backend/spec/system/support/frontend_app.rb
@@ -1,0 +1,74 @@
+module SystemSpec
+  class FrontendApp
+    include Singleton
+
+    def start(log = "/dev/null")
+      if test_connection_to_frontend_app
+        puts "Frontend app already running at #{frontend_app_url}"
+        return
+      end
+
+      puts "Starting frontend app at #{frontend_app_url}"
+      @pid ||= Process.spawn(
+        frontend_app_cmd,
+        [:out, :err] => log,
+        chdir: "../frontend"
+      )
+
+      timeout = 15.seconds
+      unless test_connection_to_frontend_app(timeout)
+        fail "Frontend app did not start within #{timeout} seconds"
+      end
+    end
+
+    def wait_on
+      return unless @pid
+      Process.wait @pid
+    end
+
+    def stop
+      return unless @pid
+      Process.kill "QUIT", @pid
+      Process.wait @pid
+    end
+
+  private
+
+    def test_connection_to_frontend_app(timeout = 0)
+       system(
+        test_connection_cmd(timeout),
+        out: "/dev/null"
+      )
+    end
+
+    def test_connection_cmd(timeout)
+      [
+        "curl --silent --head -X GET",
+        "--retry-connrefused",
+        "--retry", timeout.to_s,
+        "--retry-delay", "1",
+        frontend_app_url
+      ].join(" ")
+    end
+
+    def frontend_app_cmd
+      [
+        "./node_modules/.bin/ember", "serve",
+        "--port", frontend_port,
+        "--proxy", "http://localhost:#{backend_port}"
+      ].join(" ")
+    end
+
+    def frontend_app_url
+      "http://localhost:#{frontend_port}"
+    end
+
+    def frontend_port
+      ENV["SYSTEM_SPEC_FRONTEND_PORT"]
+    end
+
+    def backend_port
+      ENV["SYSTEM_SPEC_BACKEND_PORT"]
+    end
+  end
+end

--- a/backend/spec/system/support/frontend_app.rb
+++ b/backend/spec/system/support/frontend_app.rb
@@ -53,6 +53,9 @@ module SystemSpec
 
     def frontend_app_cmd
       [
+        "BASE_URL=#{frontend_app_url}",
+        "FRONTEND_PORT=#{frontend_port}",
+        "PORT=#{backend_port}",
         "./node_modules/.bin/ember", "serve",
         "--port", frontend_port,
         "--proxy", "http://localhost:#{backend_port}"

--- a/backend/spec/system/support/frontend_app.rb
+++ b/backend/spec/system/support/frontend_app.rb
@@ -12,7 +12,7 @@ module SystemSpec
       @pid ||= Process.spawn(
         frontend_app_cmd,
         [:out, :err] => log,
-        chdir: "../frontend"
+        :chdir => "../frontend"
       )
 
       timeout = 15.seconds
@@ -32,10 +32,10 @@ module SystemSpec
       Process.wait @pid
     end
 
-  private
+    private
 
     def test_connection_to_frontend_app(timeout = 0)
-       system(
+      system(
         test_connection_cmd(timeout),
         out: "/dev/null"
       )

--- a/backend/spec/system_spec_helper.rb
+++ b/backend/spec/system_spec_helper.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+# Most of the system spec config was borrowed, with many thanks, from:
+# https://evilmartians.com/chronicles/system-of-a-test-setting-up-end-to-end-rails-testing
+require "system/support/capybara_config"
+require "system/support/cuprite_config"
+
+RSpec.configure do |config|
+   config.prepend_before(:each, type: :system) do
+    driven_by Capybara.javascript_driver
+  end
+end

--- a/backend/spec/system_spec_helper.rb
+++ b/backend/spec/system_spec_helper.rb
@@ -2,11 +2,20 @@ require "rails_helper"
 
 # Most of the system spec config was borrowed, with many thanks, from:
 # https://evilmartians.com/chronicles/system-of-a-test-setting-up-end-to-end-rails-testing
+require "system/support/frontend_app"
 require "system/support/capybara_config"
 require "system/support/cuprite_config"
 
 RSpec.configure do |config|
-   config.prepend_before(:each, type: :system) do
+  config.prepend_before(:each, type: :system) do
     driven_by Capybara.javascript_driver
+  end
+
+  config.before(:suite) do
+    SystemSpec::FrontendApp.instance.start
+  end
+
+  config.after(:suite) do
+    SystemSpec::FrontendApp.instance.stop
   end
 end

--- a/backend/spec/system_spec_helper.rb
+++ b/backend/spec/system_spec_helper.rb
@@ -11,11 +11,15 @@ RSpec.configure do |config|
     driven_by Capybara.javascript_driver
   end
 
-  config.before(:suite) do
-    SystemSpec::FrontendApp.instance.start
-  end
+  # System specs are excluded by default in ~/.rspec
+  # bin/system_spec provides a thin shim that includes them
+  unless config.exclusion_filter[:type] == "system"
+    config.before(:suite) do
+      SystemSpec::FrontendApp.instance.start
+    end
 
-  config.after(:suite) do
-    SystemSpec::FrontendApp.instance.stop
+    config.after(:suite) do
+      SystemSpec::FrontendApp.instance.stop
+    end
   end
 end

--- a/frontend/config/environment.js
+++ b/frontend/config/environment.js
@@ -63,8 +63,8 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    ENV.apiHost = 'http://localhost:3000';
-    var STATIC_URL = 'http://localhost:4300';
+    ENV.apiHost    = 'http://localhost:' + (process.env.PORT || '3000');
+    var STATIC_URL = 'http://localhost:' + (process.env.FRONTEND_PORT || '4300');
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
Initial attempt at wiring up the frontend app to the rails backend used in system specs.

Supports two modes:
1. Automatically start `ember serve` and point it at the rails system spec backend, setting both ports from environment variables. This requires less human orchestration but is a slower dev cycle since starting the frontend app takes ~10s on each system spec run.
2. Provides a new `spec:system:start_frontend` task that spawns the frontend app with the correct port and proxy settings; system specs detect that this is already running and use it.

*Development notes*
* In order to run system specs, two new environment variables are needed. Copy over to `.env` from `backend/env-example`.
* System specs are excluded by default (in `~/.rspec`). A thin `bin/system_spec` wrapper is added to help run system specs.

*Credits*
H/T @johncarlocerna 🙌🏾 !