### PR TITLE
fix: return country data as object instead of array

### DIFF
--- a/backend/app/controllers/api/v1/countries_controller.rb
+++ b/backend/app/controllers/api/v1/countries_controller.rb
@@ -4,7 +4,7 @@ module Api
       skip_before_action :authenticate_user!
 
       def index
-        render json: Country.all, each_serializer: CountrySerializer, root: false
+        render json: Country.all, each_serializer: CountrySerializer
       end
 
       def show


### PR DESCRIPTION
Country data was being received as an array of objects, but Ember expected `{countries: [Array of country data]}`

Countries drop-down now renders correct options:
<img width="611" alt="image" src="https://github.com/rubyforgood/Flaredown/assets/58997957/98759423-b140-483d-94e9-2859a3c563db">
