### PR TITLE
Feat: Add RSwag to generate API Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ rake run
 
 Visit your app at [http://localhost:4300](http://localhost:4300)
 
+### Open API Documentation
+This project is using the rswag gem to generate interactive api documentation. You can access this documentation locally at [http://localhost:3000/api-docs/index.html](http://localhost:3000/api-docs/index.html).
+If you make changes to the api, you will need to run `bundle exec rake rswag` from the backend directory to update the generated examples.
+
 ## CI
 
 Several checks are configured to run on all commits using Github Actions, including lint, build and test steps. Definitions can be found in [./github/workflows](./github/workflows). Those checks which always run are required to be successful for PRs to be mergable.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ rake run
 Visit your app at [http://localhost:4300](http://localhost:4300)
 
 ### Open API Documentation
-This project is using the rswag gem to generate interactive api documentation. You can access this documentation locally at [http://localhost:3000/api-docs/index.html](http://localhost:3000/api-docs/index.html).
+This project is using the [rswag](https://github.com/rswag/rswag) gem to generate interactive api documentation. You can access this documentation locally at [http://localhost:3000/api-docs/index.html](http://localhost:3000/api-docs/index.html).
 If you make changes to the api, you will need to run `bundle exec rake rswag` from the backend directory to update the generated examples.
 
 ## CI

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -62,6 +62,8 @@ gem "kaminari-actionview"
 gem "kaminari-mongoid"
 gem "rack-cors", "1.1.1", require: "rack/cors" # freezing to gemfile.lock version because heroku is not respecting lockfile
 gem "simplecov", require: false, group: :test
+gem 'rswag-api'
+gem 'rswag-ui'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -78,6 +80,7 @@ group :development, :test do
   gem "pry-rails"
   gem "rspec-rails"
   gem "standardrb"
+  gem 'rswag-specs'
 end
 
 group :development do

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -62,8 +62,8 @@ gem "kaminari-actionview"
 gem "kaminari-mongoid"
 gem "rack-cors", "1.1.1", require: "rack/cors" # freezing to gemfile.lock version because heroku is not respecting lockfile
 gem "simplecov", require: false, group: :test
-gem 'rswag-api'
-gem 'rswag-ui'
+gem "rswag-api"
+gem "rswag-ui"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -80,7 +80,7 @@ group :development, :test do
   gem "pry-rails"
   gem "rspec-rails"
   gem "standardrb"
-  gem 'rswag-specs'
+  gem "rswag-specs"
 end
 
 group :development do

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -193,6 +193,8 @@ GEM
     i18n_data (0.13.0)
     json (2.6.3)
     json (2.6.3-java)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     jwt (2.3.0)
     kaminari-actionview (1.2.1)
       actionview
@@ -383,6 +385,17 @@ GEM
     rspec-support (3.12.1)
     rubocop (1.52.1)
       json (~> 2.3)
+    rswag-api (2.10.1)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.10.1)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.10.1)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
+    rubocop (1.20.0)
       parallel (~> 1.10)
       parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
@@ -515,6 +528,13 @@ DEPENDENCIES
   rails_12factor
   rake
   rspec-rails
+<<<<<<< HEAD
+=======
+  rswag-api
+  rswag-specs
+  rswag-ui
+  rubocop-rails
+>>>>>>> 9d534a25 (feat: add rswag gem)
   ruby-progressbar
   seedbank
   shoulda-matchers

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -383,8 +383,6 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    rubocop (1.52.1)
-      json (~> 2.3)
     rswag-api (2.10.1)
       railties (>= 3.1, < 7.1)
     rswag-specs (2.10.1)
@@ -395,7 +393,8 @@ GEM
     rswag-ui (2.10.1)
       actionpack (>= 3.1, < 7.1)
       railties (>= 3.1, < 7.1)
-    rubocop (1.20.0)
+    rubocop (1.52.1)
+      json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
@@ -531,7 +530,6 @@ DEPENDENCIES
   rswag-api
   rswag-specs
   rswag-ui
-  rubocop-rails
   ruby-progressbar
   seedbank
   shoulda-matchers

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     i18n_data (0.13.0)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     jwt (2.3.0)
     kaminari-actionview (1.2.1)
       actionview
@@ -377,6 +379,16 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rswag-api (2.10.1)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.10.1)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.10.1)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.20.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -505,6 +517,9 @@ DEPENDENCIES
   rails_12factor
   rake
   rspec-rails
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop-rails
   ruby-progressbar
   seedbank

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -2,7 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path("../config/application", __FILE__)
-require_relative 'config/application'
+require_relative "config/application"
 
 # Workaround for https://github.com/rswag/rswag/issues/359
 if defined? RSpec

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -2,4 +2,13 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path("../config/application", __FILE__)
+require_relative 'config/application'
+
+# Workaround for https://github.com/rswag/rswag/issues/359
+if defined? RSpec
+  RSpec.configure do |config|
+    config.swagger_dry_run = false
+  end
+end
+
 Rails.application.load_tasks

--- a/backend/config/initializers/rswag_api.rb
+++ b/backend/config/initializers/rswag_api.rb
@@ -1,14 +1,13 @@
 Rswag::Api.configure do |c|
-
   # Specify a root folder where Swagger JSON files are located
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.to_s + '/swagger'
+  c.swagger_root = Rails.root.to_s + "/swagger"
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request
   # For example, you could leverage this to dynamically assign the "host" property
   #
-  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
 end

--- a/backend/config/initializers/rswag_api.rb
+++ b/backend/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/backend/config/initializers/rswag_ui.rb
+++ b/backend/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/backend/config/initializers/rswag_ui.rb
+++ b/backend/config/initializers/rswag_ui.rb
@@ -1,5 +1,4 @@
 Rswag::Ui.configure do |c|
-
   # List the Swagger endpoints that you want to be documented through the
   # swagger-ui. The first parameter is the path (absolute or relative to the UI
   # host) to the corresponding endpoint and the second is a title that will be
@@ -8,7 +7,7 @@ Rswag::Ui.configure do |c|
   # (under swagger_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
   root "application#root"
 

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,8 +1,11 @@
 # rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
-  mount Rswag::Ui::Engine => '/api-docs'
-  mount Rswag::Api::Engine => '/api-docs'
+  if Rails.env.development?
+    mount Rswag::Ui::Engine => '/api-docs'
+    mount Rswag::Api::Engine => '/api-docs'
+  end
+
   root "application#root"
 
   # Authentication

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
+  mount Rswag::Api::Engine => '/api-docs'
   root "application#root"
 
   # Authentication

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,8 +2,8 @@
 
 Rails.application.routes.draw do
   if Rails.env.development?
-    mount Rswag::Ui::Engine => '/api-docs'
-    mount Rswag::Api::Engine => '/api-docs'
+    mount Rswag::Ui::Engine => "/api-docs"
+    mount Rswag::Api::Engine => "/api-docs"
   end
 
   root "application#root"

--- a/backend/spec/requests/api/v1/checkins_spec.rb
+++ b/backend/spec/requests/api/v1/checkins_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/checkins', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -27,7 +28,8 @@ RSpec.describe 'api/v1/checkins', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -47,7 +49,8 @@ RSpec.describe 'api/v1/checkins', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -62,7 +65,8 @@ RSpec.describe 'api/v1/checkins', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -77,7 +81,8 @@ RSpec.describe 'api/v1/checkins', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/checkins_spec.rb
+++ b/backend/spec/requests/api/v1/checkins_spec.rb
@@ -1,0 +1,85 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/checkins', type: :request do
+
+  path '/api/checkins' do
+
+    get('list checkins') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create checkin') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/checkins/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show checkin') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    patch('update checkin') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    put('update checkin') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/checkins_spec.rb
+++ b/backend/spec/requests/api/v1/checkins_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/checkins', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/checkins' do
 

--- a/backend/spec/requests/api/v1/checkins_spec.rb
+++ b/backend/spec/requests/api/v1/checkins_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/checkins', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/checkins' do
 
     get('list checkins') do

--- a/backend/spec/requests/api/v1/checkins_spec.rb
+++ b/backend/spec/requests/api/v1/checkins_spec.rb
@@ -1,87 +1,84 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/checkins', type: :request do
-  path '/api/checkins' do
-
-    get('list checkins') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/checkins", type: :request do
+  path "/api/checkins" do
+    get("list checkins") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    post('create checkin') do
-      response(200, 'successful') do
-
+    post("create checkin") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/checkins/{id}' do
+  path "/api/checkins/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show checkin') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show checkin") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    patch('update checkin') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    patch("update checkin") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    put('update checkin') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    put("update checkin") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/conditions_spec.rb
+++ b/backend/spec/requests/api/v1/conditions_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/conditions', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/conditions' do
 
     get('list conditions') do

--- a/backend/spec/requests/api/v1/conditions_spec.rb
+++ b/backend/spec/requests/api/v1/conditions_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/conditions', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -27,7 +28,8 @@ RSpec.describe 'api/v1/conditions', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -47,7 +49,8 @@ RSpec.describe 'api/v1/conditions', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/conditions_spec.rb
+++ b/backend/spec/requests/api/v1/conditions_spec.rb
@@ -1,55 +1,52 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/conditions', type: :request do
-  path '/api/conditions' do
-
-    get('list conditions') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/conditions", type: :request do
+  path "/api/conditions" do
+    get("list conditions") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    post('create condition') do
-      response(200, 'successful') do
-
+    post("create condition") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/conditions/{id}' do
+  path "/api/conditions/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show condition') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show condition") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/conditions_spec.rb
+++ b/backend/spec/requests/api/v1/conditions_spec.rb
@@ -1,0 +1,55 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/conditions', type: :request do
+
+  path '/api/conditions' do
+
+    get('list conditions') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create condition') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/conditions/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show condition') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/conditions_spec.rb
+++ b/backend/spec/requests/api/v1/conditions_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/conditions', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/conditions' do
 

--- a/backend/spec/requests/api/v1/countries_spec.rb
+++ b/backend/spec/requests/api/v1/countries_spec.rb
@@ -1,9 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/countries', type: :request do
-  let!(:user) { create(:user) }
-
-  before { sign_in user }
+  before { sign_in create(:user) }
 
   path '/api/countries' do
 

--- a/backend/spec/requests/api/v1/countries_spec.rb
+++ b/backend/spec/requests/api/v1/countries_spec.rb
@@ -1,40 +1,38 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/countries', type: :request do
-  path '/api/countries' do
-
-    get('list countries') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/countries", type: :request do
+  path "/api/countries" do
+    get("list countries") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/countries/{id}' do
+  path "/api/countries/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show country') do
-      response(200, 'successful') do
-        let(:id) { 'US' }
+    get("show country") do
+      response(200, "successful") do
+        let(:id) { "US" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/countries_spec.rb
+++ b/backend/spec/requests/api/v1/countries_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/countries', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/countries' do
 
     get('list countries') do

--- a/backend/spec/requests/api/v1/countries_spec.rb
+++ b/backend/spec/requests/api/v1/countries_spec.rb
@@ -1,0 +1,44 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/countries', type: :request do
+  let!(:user) { create(:user) }
+
+  before { sign_in user }
+
+  path '/api/countries' do
+
+    get('list countries') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/countries/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show country') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/countries_spec.rb
+++ b/backend/spec/requests/api/v1/countries_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe "api/v1/countries", type: :request do
             }
           }
         end
-        pending "Not yet implemented, when implemented uncomment the assertion below"
-        # run_test!
+        run_test!
       end
     end
   end
@@ -32,8 +31,7 @@ RSpec.describe "api/v1/countries", type: :request do
             }
           }
         end
-        pending "Not yet implemented, when implemented uncomment the assertion below"
-        # run_test!
+        run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/countries_spec.rb
+++ b/backend/spec/requests/api/v1/countries_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/countries', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -33,7 +34,8 @@ RSpec.describe 'api/v1/countries', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/countries_spec.rb
+++ b/backend/spec/requests/api/v1/countries_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'api/v1/countries', type: :request do
 
     get('show country') do
       response(200, 'successful') do
-        let(:id) { '123' }
+        let(:id) { 'US' }
 
         after do |example|
           example.metadata[:response][:content] = {

--- a/backend/spec/requests/api/v1/day_habits_spec.rb
+++ b/backend/spec/requests/api/v1/day_habits_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/day_habits', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -33,7 +34,8 @@ RSpec.describe 'api/v1/day_habits', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/day_habits_spec.rb
+++ b/backend/spec/requests/api/v1/day_habits_spec.rb
@@ -1,40 +1,38 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/day_habits', type: :request do
-  path '/api/day_habits' do
-
-    get('list day_habits') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/day_habits", type: :request do
+  path "/api/day_habits" do
+    get("list day_habits") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/day_habits/{id}' do
+  path "/api/day_habits/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show day_habit') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show day_habit") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/day_habits_spec.rb
+++ b/backend/spec/requests/api/v1/day_habits_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/day_habits', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/day_habits' do
 
     get('list day_habits') do

--- a/backend/spec/requests/api/v1/day_habits_spec.rb
+++ b/backend/spec/requests/api/v1/day_habits_spec.rb
@@ -1,0 +1,41 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/day_habits', type: :request do
+
+  path '/api/day_habits' do
+
+    get('list day_habits') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/day_habits/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show day_habit') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/day_habits_spec.rb
+++ b/backend/spec/requests/api/v1/day_habits_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/day_habits', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/day_habits' do
 

--- a/backend/spec/requests/api/v1/education_levels_spec.rb
+++ b/backend/spec/requests/api/v1/education_levels_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/education_levels', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/education_levels' do
 
     get('list education_levels') do

--- a/backend/spec/requests/api/v1/education_levels_spec.rb
+++ b/backend/spec/requests/api/v1/education_levels_spec.rb
@@ -1,40 +1,38 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/education_levels', type: :request do
-  path '/api/education_levels' do
-
-    get('list education_levels') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/education_levels", type: :request do
+  path "/api/education_levels" do
+    get("list education_levels") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/education_levels/{id}' do
+  path "/api/education_levels/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show education_level') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show education_level") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/education_levels_spec.rb
+++ b/backend/spec/requests/api/v1/education_levels_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/education_levels', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -33,7 +34,8 @@ RSpec.describe 'api/v1/education_levels', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/education_levels_spec.rb
+++ b/backend/spec/requests/api/v1/education_levels_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/education_levels', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/education_levels' do
 

--- a/backend/spec/requests/api/v1/education_levels_spec.rb
+++ b/backend/spec/requests/api/v1/education_levels_spec.rb
@@ -1,0 +1,41 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/education_levels', type: :request do
+
+  path '/api/education_levels' do
+
+    get('list education_levels') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/education_levels/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show education_level') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/ethnicities_spec.rb
+++ b/backend/spec/requests/api/v1/ethnicities_spec.rb
@@ -1,0 +1,41 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/ethnicities', type: :request do
+
+  path '/api/ethnicities' do
+
+    get('list ethnicities') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/ethnicities/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show ethnicity') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/ethnicities_spec.rb
+++ b/backend/spec/requests/api/v1/ethnicities_spec.rb
@@ -1,40 +1,38 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/ethnicities', type: :request do
-  path '/api/ethnicities' do
-
-    get('list ethnicities') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/ethnicities", type: :request do
+  path "/api/ethnicities" do
+    get("list ethnicities") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/ethnicities/{id}' do
+  path "/api/ethnicities/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show ethnicity') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show ethnicity") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/ethnicities_spec.rb
+++ b/backend/spec/requests/api/v1/ethnicities_spec.rb
@@ -11,19 +11,17 @@ RSpec.describe "api/v1/ethnicities", type: :request do
             }
           }
         end
-        pending "Not yet implemented, when implemented uncomment the assertion below"
-        # run_test!
+        run_test!
       end
     end
   end
 
   path "/api/ethnicities/{id}" do
-    # You'll want to customize the parameter types...
     parameter name: "id", in: :path, type: :string, description: "id"
 
     get("show ethnicity") do
       response(200, "successful") do
-        let(:id) { "123" }
+        let(:id) { "latino" }
 
         after do |example|
           example.metadata[:response][:content] = {
@@ -32,8 +30,7 @@ RSpec.describe "api/v1/ethnicities", type: :request do
             }
           }
         end
-        pending "Not yet implemented, when implemented uncomment the assertion below"
-        # run_test!
+        run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/ethnicities_spec.rb
+++ b/backend/spec/requests/api/v1/ethnicities_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/ethnicities', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/ethnicities' do
 
     get('list ethnicities') do

--- a/backend/spec/requests/api/v1/ethnicities_spec.rb
+++ b/backend/spec/requests/api/v1/ethnicities_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/ethnicities', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/ethnicities' do
 

--- a/backend/spec/requests/api/v1/ethnicities_spec.rb
+++ b/backend/spec/requests/api/v1/ethnicities_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/ethnicities', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -33,7 +34,8 @@ RSpec.describe 'api/v1/ethnicities', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/passwords_spec.rb
@@ -1,0 +1,71 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/passwords', type: :request do
+
+  path '/api/passwords' do
+
+    post('create password') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/passwords/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show password') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    patch('update password') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    put('update password') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/passwords_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/passwords', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -33,7 +34,8 @@ RSpec.describe 'api/v1/passwords', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -48,7 +50,8 @@ RSpec.describe 'api/v1/passwords', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -63,7 +66,8 @@ RSpec.describe 'api/v1/passwords', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/passwords_spec.rb
@@ -1,72 +1,70 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/passwords', type: :request do
-  path '/api/passwords' do
-
-    post('create password') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/passwords", type: :request do
+  path "/api/passwords" do
+    post("create password") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/passwords/{id}' do
+  path "/api/passwords/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show password') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show password") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    patch('update password') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    patch("update password") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    put('update password') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    put("update password") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/passwords_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/passwords', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/passwords' do
 

--- a/backend/spec/requests/api/v1/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/passwords_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/passwords', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/passwords' do
 
     post('create password') do

--- a/backend/spec/requests/api/v1/posts_spec.rb
+++ b/backend/spec/requests/api/v1/posts_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/posts', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/posts' do
 

--- a/backend/spec/requests/api/v1/posts_spec.rb
+++ b/backend/spec/requests/api/v1/posts_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/posts', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -27,7 +28,8 @@ RSpec.describe 'api/v1/posts', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -47,7 +49,8 @@ RSpec.describe 'api/v1/posts', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/posts_spec.rb
+++ b/backend/spec/requests/api/v1/posts_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/posts', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/posts' do
 
     get('list posts') do

--- a/backend/spec/requests/api/v1/posts_spec.rb
+++ b/backend/spec/requests/api/v1/posts_spec.rb
@@ -1,55 +1,52 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/posts', type: :request do
-  path '/api/posts' do
-
-    get('list posts') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/posts", type: :request do
+  path "/api/posts" do
+    get("list posts") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    post('create post') do
-      response(200, 'successful') do
-
+    post("create post") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/posts/{id}' do
+  path "/api/posts/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show post') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show post") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/posts_spec.rb
+++ b/backend/spec/requests/api/v1/posts_spec.rb
@@ -1,0 +1,55 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/posts', type: :request do
+
+  path '/api/posts' do
+
+    get('list posts') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create post') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/posts/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show post') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/profiles_spec.rb
+++ b/backend/spec/requests/api/v1/profiles_spec.rb
@@ -1,72 +1,70 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/profiles', type: :request do
-  path '/api/profiles' do
-
-    get('list profiles') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/profiles", type: :request do
+  path "/api/profiles" do
+    get("list profiles") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/profiles/{id}' do
+  path "/api/profiles/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show profile') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show profile") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    patch('update profile') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    patch("update profile") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    put('update profile') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    put("update profile") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/profiles_spec.rb
+++ b/backend/spec/requests/api/v1/profiles_spec.rb
@@ -1,0 +1,71 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/profiles', type: :request do
+
+  path '/api/profiles' do
+
+    get('list profiles') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/profiles/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show profile') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    patch('update profile') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    put('update profile') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/profiles_spec.rb
+++ b/backend/spec/requests/api/v1/profiles_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/profiles', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/profiles' do
 
     get('list profiles') do

--- a/backend/spec/requests/api/v1/profiles_spec.rb
+++ b/backend/spec/requests/api/v1/profiles_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/profiles', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -33,7 +34,8 @@ RSpec.describe 'api/v1/profiles', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -48,7 +50,8 @@ RSpec.describe 'api/v1/profiles', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -63,7 +66,8 @@ RSpec.describe 'api/v1/profiles', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/profiles_spec.rb
+++ b/backend/spec/requests/api/v1/profiles_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/profiles', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/profiles' do
 

--- a/backend/spec/requests/api/v1/registrations_spec.rb
+++ b/backend/spec/requests/api/v1/registrations_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/registrations', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/registrations/destroy' do
 
     put('delete registration') do

--- a/backend/spec/requests/api/v1/registrations_spec.rb
+++ b/backend/spec/requests/api/v1/registrations_spec.rb
@@ -1,0 +1,38 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/registrations', type: :request do
+
+  path '/api/registrations/destroy' do
+
+    put('delete registration') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/registrations' do
+
+    post('create registration') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/registrations_spec.rb
+++ b/backend/spec/requests/api/v1/registrations_spec.rb
@@ -1,38 +1,34 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/registrations', type: :request do
-  path '/api/registrations/destroy' do
-
-    put('delete registration') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/registrations", type: :request do
+  path "/api/registrations/destroy" do
+    put("delete registration") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         #  pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/registrations' do
-
-    post('create registration') do
-      response(200, 'successful') do
-
+  path "/api/registrations" do
+    post("create registration") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/registrations_spec.rb
+++ b/backend/spec/requests/api/v1/registrations_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe 'api/v1/registrations', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        #  pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -30,7 +32,8 @@ RSpec.describe 'api/v1/registrations', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/registrations_spec.rb
+++ b/backend/spec/requests/api/v1/registrations_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/registrations', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/registrations/destroy' do
 

--- a/backend/spec/requests/api/v1/searches_spec.rb
+++ b/backend/spec/requests/api/v1/searches_spec.rb
@@ -1,0 +1,21 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/searches', type: :request do
+
+  path '/api/searches' do
+
+    get('show search') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/searches_spec.rb
+++ b/backend/spec/requests/api/v1/searches_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/searches', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/searches' do
 

--- a/backend/spec/requests/api/v1/searches_spec.rb
+++ b/backend/spec/requests/api/v1/searches_spec.rb
@@ -1,19 +1,17 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/searches', type: :request do
-  path '/api/searches' do
-
-    get('show search') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/searches", type: :request do
+  path "/api/searches" do
+    get("show search") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/searches_spec.rb
+++ b/backend/spec/requests/api/v1/searches_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/searches', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/searches_spec.rb
+++ b/backend/spec/requests/api/v1/searches_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/searches', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/searches' do
 
     get('show search') do

--- a/backend/spec/requests/api/v1/sexes_spec.rb
+++ b/backend/spec/requests/api/v1/sexes_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/sexes', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -33,7 +34,8 @@ RSpec.describe 'api/v1/sexes', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/sexes_spec.rb
+++ b/backend/spec/requests/api/v1/sexes_spec.rb
@@ -11,19 +11,17 @@ RSpec.describe "api/v1/sexes", type: :request do
             }
           }
         end
-        pending "Not yet implemented, when implemented uncomment the assertion below"
-        # run_test!
+        run_test!
       end
     end
   end
 
   path "/api/sexes/{id}" do
-    # You'll want to customize the parameter types...
     parameter name: "id", in: :path, type: :string, description: "id"
 
     get("show sex") do
       response(200, "successful") do
-        let(:id) { "123" }
+        let(:id) { "female" }
 
         after do |example|
           example.metadata[:response][:content] = {
@@ -32,8 +30,7 @@ RSpec.describe "api/v1/sexes", type: :request do
             }
           }
         end
-        pending "Not yet implemented, when implemented uncomment the assertion below"
-        # run_test!
+        run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/sexes_spec.rb
+++ b/backend/spec/requests/api/v1/sexes_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/sexes', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/sexes' do
 

--- a/backend/spec/requests/api/v1/sexes_spec.rb
+++ b/backend/spec/requests/api/v1/sexes_spec.rb
@@ -1,40 +1,38 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/sexes', type: :request do
-  path '/api/sexes' do
-
-    get('list sexes') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/sexes", type: :request do
+  path "/api/sexes" do
+    get("list sexes") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/sexes/{id}' do
+  path "/api/sexes/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show sex') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show sex") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/sexes_spec.rb
+++ b/backend/spec/requests/api/v1/sexes_spec.rb
@@ -1,0 +1,41 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/sexes', type: :request do
+
+  path '/api/sexes' do
+
+    get('list sexes') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/sexes/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show sex') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/sexes_spec.rb
+++ b/backend/spec/requests/api/v1/sexes_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/sexes', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/sexes' do
 
     get('list sexes') do

--- a/backend/spec/requests/api/v1/symptoms_spec.rb
+++ b/backend/spec/requests/api/v1/symptoms_spec.rb
@@ -1,4 +1,3 @@
-require "rails_helper"
 require "swagger_helper"
 
 RSpec.describe "api/v1/symptoms", type: :request do
@@ -8,23 +7,6 @@ RSpec.describe "api/v1/symptoms", type: :request do
       produces "application/json"
 
       response(200, "successful") do
-        schema type: :object,
-          properties: {
-            symptom: {
-              type: :object,
-              properties: {
-                id: {type: :integer, required: true},
-                updated_at: {type: :string, required: true},
-                created_at: {type: :string, required: true},
-                type: {type: :string, required: true},
-                color_id: {type: :integer, nullable: true},
-                users_count: {type: :integer, required: true},
-                name: {type: :string, required: true}
-              }
-            }
-          },
-          required: [:symptom]
-
         let(:id) { create(:symptom).id }
 
         after do |example|
@@ -34,8 +16,7 @@ RSpec.describe "api/v1/symptoms", type: :request do
             }
           }
         end
-        pending "Not yet implemented, when implemented uncomment the assertion below"
-        # run_test!
+        run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/symptoms_spec.rb
+++ b/backend/spec/requests/api/v1/symptoms_spec.rb
@@ -1,40 +1,39 @@
 require "rails_helper"
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/symptoms', type: :request do
+RSpec.describe "api/v1/symptoms", type: :request do
   let!(:user) { create(:user) }
 
   before { sign_in user }
 
-  path '/api/symptoms/{id}' do
+  path "/api/symptoms/{id}" do
+    get("show symptom") do
+      parameter name: "id", in: :path, type: :integer, description: "id"
+      produces "application/json"
 
-    get('show symptom') do
-      parameter name: 'id', in: :path, type: :integer, description: 'id'
-      produces 'application/json'
-
-      response(200, 'successful') do
+      response(200, "successful") do
         schema type: :object,
-               properties: {
-                 symptom: {
-                   type: :object,
-                   properties: {
-                     id: { type: :integer, required: true },
-                     updated_at: { type: :string, required: true },
-                     created_at: { type: :string, required: true },
-                     type: { type: :string, required: true },
-                     color_id: { type: :integer, nullable: true },
-                     users_count: { type: :integer, required: true },
-                     name: { type: :string, required: true },
-                   },
-                 }
-               },
-                required: [:symptom]
+          properties: {
+            symptom: {
+              type: :object,
+              properties: {
+                id: {type: :integer, required: true},
+                updated_at: {type: :string, required: true},
+                created_at: {type: :string, required: true},
+                type: {type: :string, required: true},
+                color_id: {type: :integer, nullable: true},
+                users_count: {type: :integer, required: true},
+                name: {type: :string, required: true}
+              }
+            }
+          },
+          required: [:symptom]
 
         let(:id) { create(:symptom).id }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }

--- a/backend/spec/requests/api/v1/symptoms_spec.rb
+++ b/backend/spec/requests/api/v1/symptoms_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "api/v1/symptoms", type: :request do
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/symptoms_spec.rb
+++ b/backend/spec/requests/api/v1/symptoms_spec.rb
@@ -2,8 +2,6 @@ require "rails_helper"
 require "swagger_helper"
 
 RSpec.describe "api/v1/symptoms", type: :request do
-  before { sign_in create(:user) }
-
   path "/api/symptoms/{id}" do
     get("show symptom") do
       parameter name: "id", in: :path, type: :integer, description: "id"

--- a/backend/spec/requests/api/v1/symptoms_spec.rb
+++ b/backend/spec/requests/api/v1/symptoms_spec.rb
@@ -6,37 +6,6 @@ RSpec.describe 'api/v1/symptoms', type: :request do
 
   before { sign_in user }
 
-  path '/api/symptoms' do
-
-    get('list symptoms') do
-      response(200, 'successful') do
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-        run_test!
-      end
-    end
-
-    post('create symptom') do
-      response(200, 'successful') do
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-        run_test!
-      end
-    end
-  end
-
   path '/api/symptoms/{id}' do
 
     get('show symptom') do

--- a/backend/spec/requests/api/v1/symptoms_spec.rb
+++ b/backend/spec/requests/api/v1/symptoms_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe "api/v1/symptoms", type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/symptoms_spec.rb
+++ b/backend/spec/requests/api/v1/symptoms_spec.rb
@@ -2,9 +2,7 @@ require "rails_helper"
 require "swagger_helper"
 
 RSpec.describe "api/v1/symptoms", type: :request do
-  let!(:user) { create(:user) }
-
-  before { sign_in user }
+  before { sign_in create(:user) }
 
   path "/api/symptoms/{id}" do
     get("show symptom") do

--- a/backend/spec/requests/api/v1/symptoms_spec.rb
+++ b/backend/spec/requests/api/v1/symptoms_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/symptoms', type: :request do
+  let!(:user) { create(:user) }
+
+  before { sign_in user }
+
+  path '/api/symptoms' do
+
+    get('list symptoms') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create symptom') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/symptoms/{id}' do
+
+    get('show symptom') do
+      parameter name: 'id', in: :path, type: :integer, description: 'id'
+      produces 'application/json'
+
+      response(200, 'successful') do
+        schema type: :object,
+               properties: {
+                 symptom: {
+                   type: :object,
+                   properties: {
+                     id: { type: :integer, required: true },
+                     updated_at: { type: :string, required: true },
+                     created_at: { type: :string, required: true },
+                     type: { type: :string, required: true },
+                     color_id: { type: :integer, nullable: true },
+                     users_count: { type: :integer, required: true },
+                     name: { type: :string, required: true },
+                   },
+                 }
+               },
+                required: [:symptom]
+
+        let(:id) { create(:symptom).id }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/tags_spec.rb
+++ b/backend/spec/requests/api/v1/tags_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/tags', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/tags' do
 
     get('list tags') do

--- a/backend/spec/requests/api/v1/tags_spec.rb
+++ b/backend/spec/requests/api/v1/tags_spec.rb
@@ -1,55 +1,52 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/tags', type: :request do
-  path '/api/tags' do
-
-    get('list tags') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/tags", type: :request do
+  path "/api/tags" do
+    get("list tags") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    post('create tag') do
-      response(200, 'successful') do
-
+    post("create tag") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/tags/{id}' do
+  path "/api/tags/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show tag') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show tag") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/tags_spec.rb
+++ b/backend/spec/requests/api/v1/tags_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/tags', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/tags' do
 

--- a/backend/spec/requests/api/v1/tags_spec.rb
+++ b/backend/spec/requests/api/v1/tags_spec.rb
@@ -1,0 +1,55 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/tags', type: :request do
+
+  path '/api/tags' do
+
+    get('list tags') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create tag') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/tags/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show tag') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/tags_spec.rb
+++ b/backend/spec/requests/api/v1/tags_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/tags', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -27,7 +28,8 @@ RSpec.describe 'api/v1/tags', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -47,7 +49,8 @@ RSpec.describe 'api/v1/tags', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/trackings_spec.rb
+++ b/backend/spec/requests/api/v1/trackings_spec.rb
@@ -1,71 +1,68 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/trackings', type: :request do
-  path '/api/trackings' do
-
-    get('list trackings') do
-      response(200, 'successful') do
-
+RSpec.describe "api/v1/trackings", type: :request do
+  path "/api/trackings" do
+    get("list trackings") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    post('create tracking') do
-      response(200, 'successful') do
-
+    post("create tracking") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/trackings/{id}' do
+  path "/api/trackings/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show tracking') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    get("show tracking") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    delete('delete tracking') do
-      response(200, 'successful') do
-        let(:id) { '123' }
+    delete("delete tracking") do
+      response(200, "successful") do
+        let(:id) { "123" }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/trackings_spec.rb
+++ b/backend/spec/requests/api/v1/trackings_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/trackings', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/trackings' do
 

--- a/backend/spec/requests/api/v1/trackings_spec.rb
+++ b/backend/spec/requests/api/v1/trackings_spec.rb
@@ -1,0 +1,70 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/trackings', type: :request do
+
+  path '/api/trackings' do
+
+    get('list trackings') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create tracking') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/trackings/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show tracking') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    delete('delete tracking') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/trackings_spec.rb
+++ b/backend/spec/requests/api/v1/trackings_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/trackings', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -27,7 +28,8 @@ RSpec.describe 'api/v1/trackings', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -47,7 +49,8 @@ RSpec.describe 'api/v1/trackings', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
@@ -62,7 +65,8 @@ RSpec.describe 'api/v1/trackings', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/trackings_spec.rb
+++ b/backend/spec/requests/api/v1/trackings_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/trackings', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/trackings' do
 
     get('list trackings') do

--- a/backend/spec/requests/api/v1/treatments_spec.rb
+++ b/backend/spec/requests/api/v1/treatments_spec.rb
@@ -2,6 +2,9 @@ require 'swagger_helper'
 
 RSpec.describe 'api/v1/treatments', type: :request do
   path '/api/treatments' do
+    before do
+      create_list(:treatment, 3)
+    end
 
     get('list treatments') do
       response(200, 'successful') do
@@ -13,12 +16,15 @@ RSpec.describe 'api/v1/treatments', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
     post('create treatment') do
+      parameter name: :treatment, in: :body
       response(200, 'successful') do
+        let(:treatment) { {treatment: { name: 'Aspirin' }} }
 
         after do |example|
           example.metadata[:response][:content] = {
@@ -27,7 +33,8 @@ RSpec.describe 'api/v1/treatments', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end
@@ -38,7 +45,7 @@ RSpec.describe 'api/v1/treatments', type: :request do
 
     get('show treatment') do
       response(200, 'successful') do
-        let(:id) { '123' }
+        let(:id) { Treatment.pick(:id) }
 
         after do |example|
           example.metadata[:response][:content] = {
@@ -47,7 +54,8 @@ RSpec.describe 'api/v1/treatments', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/treatments_spec.rb
+++ b/backend/spec/requests/api/v1/treatments_spec.rb
@@ -1,60 +1,59 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/treatments', type: :request do
-  path '/api/treatments' do
+RSpec.describe "api/v1/treatments", type: :request do
+  path "/api/treatments" do
     before do
       create_list(:treatment, 3)
     end
 
-    get('list treatments') do
-      response(200, 'successful') do
-
+    get("list treatments") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
 
-    post('create treatment') do
+    post("create treatment") do
       parameter name: :treatment, in: :body
-      response(200, 'successful') do
-        let(:treatment) { {treatment: { name: 'Aspirin' }} }
+      response(200, "successful") do
+        let(:treatment) { {treatment: {name: "Aspirin"}} }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
   end
 
-  path '/api/treatments/{id}' do
+  path "/api/treatments/{id}" do
     # You'll want to customize the parameter types...
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+    parameter name: "id", in: :path, type: :string, description: "id"
 
-    get('show treatment') do
-      response(200, 'successful') do
+    get("show treatment") do
+      response(200, "successful") do
         let(:id) { Treatment.pick(:id) }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/treatments_spec.rb
+++ b/backend/spec/requests/api/v1/treatments_spec.rb
@@ -1,0 +1,55 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/treatments', type: :request do
+
+  path '/api/treatments' do
+
+    get('list treatments') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create treatment') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/treatments/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show treatment') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/treatments_spec.rb
+++ b/backend/spec/requests/api/v1/treatments_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/treatments', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/treatments' do
 

--- a/backend/spec/requests/api/v1/treatments_spec.rb
+++ b/backend/spec/requests/api/v1/treatments_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/treatments', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/treatments' do
 
     get('list treatments') do

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -1,8 +1,6 @@
 require "swagger_helper"
 
 RSpec.describe "api/v1/users", type: :request do
-  before { sign_in create(:user) }
-
   path "/api/users/{id}" do
     parameter name: "id", in: :path, type: :string, description: "id"
 

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -1,21 +1,18 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/users', type: :request do
+RSpec.describe "api/v1/users", type: :request do
   before { sign_in create(:user) }
 
-
-  path '/api/users/{id}' do
-    parameter name: 'id', in: :path, type: :string, description: 'id'
+  path "/api/users/{id}" do
+    parameter name: "id", in: :path, type: :string, description: "id"
 
     let(:id) { User.pick(:id) }
 
-
-    get('show user') do
-      response(200, 'successful') do
-
+    get("show user") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
@@ -24,41 +21,13 @@ RSpec.describe 'api/v1/users', type: :request do
       end
     end
 
-    patch('update user') do
-      consumes 'application/json'
-      parameter name: :params, in: :body, schema: {
-        type: :object,
-        properties: {
-          user: {
-            type: :object,
-            properties: {
-              email: { type: :string },
-            }
-        }
-        },
-        required: [ 'user' ]
-      }
-      response(200, 'successful') do
-
-        let(:params) { {user: { email: 'updatedemail@example.com'} } }
+    patch("update user") do
+      response(200, "successful", use_as_request_example: true) do
+        let(:params) { {user: {email: "updatedemail@example.com"}} }
 
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-        run_test!
-      end
-    end
-
-    put('update user') do
-      response(200, 'successful') do
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/users', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/users/{id}' do
     # You'll want to customize the parameter types...

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -1,13 +1,17 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/users', type: :request do
+  before { sign_in create(:user) }
+
+
   path '/api/users/{id}' do
-    # You'll want to customize the parameter types...
     parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    let(:id) { User.pick(:id) }
+
 
     get('show user') do
       response(200, 'successful') do
-        let(:id) { '123' }
 
         after do |example|
           example.metadata[:response][:content] = {
@@ -21,8 +25,22 @@ RSpec.describe 'api/v1/users', type: :request do
     end
 
     patch('update user') do
+      consumes 'application/json'
+      parameter name: :params, in: :body, schema: {
+        type: :object,
+        properties: {
+          user: {
+            type: :object,
+            properties: {
+              email: { type: :string },
+            }
+        }
+        },
+        required: [ 'user' ]
+      }
       response(200, 'successful') do
-        let(:id) { '123' }
+
+        let(:params) { {user: { email: 'updatedemail@example.com'} } }
 
         after do |example|
           example.metadata[:response][:content] = {
@@ -37,7 +55,6 @@ RSpec.describe 'api/v1/users', type: :request do
 
     put('update user') do
       response(200, 'successful') do
-        let(:id) { '123' }
 
         after do |example|
           example.metadata[:response][:content] = {

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "api/v1/users", type: :request do
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end
@@ -23,8 +23,7 @@ RSpec.describe "api/v1/users", type: :request do
     patch("update user") do
       parameter name: :user, in: :body
       response(200, "successful") do
-
-        let(:user) { { user: { email: "updatedemail@example.com" } } }
+        let(:user) { {user: {email: "updatedemail@example.com"}} }
         after do |example|
           example.metadata[:response][:content] = {
             "application/json" => {

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -15,14 +15,16 @@ RSpec.describe "api/v1/users", type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
 
     patch("update user") do
-      response(200, "successful", use_as_request_example: true) do
-        let(:params) { {user: {email: "updatedemail@example.com"}} }
+      parameter name: :user, in: :body
+      response(200, "successful") do
 
+        let(:user) { { user: { email: "updatedemail@example.com" } } }
         after do |example|
           example.metadata[:response][:content] = {
             "application/json" => {
@@ -30,7 +32,8 @@ RSpec.describe "api/v1/users", type: :request do
             }
           }
         end
-        run_test!
+        pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "api/v1/users", type: :request do
 
     patch("update user") do
       parameter name: :user, in: :body
+
       response(200, "successful") do
         let(:user) { {user: {email: "updatedemail@example.com"}} }
         after do |example|

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/users', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/users/{id}' do
     # You'll want to customize the parameter types...
     parameter name: 'id', in: :path, type: :string, description: 'id'

--- a/backend/spec/requests/api/v1/users_spec.rb
+++ b/backend/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,54 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/users', type: :request do
+
+  path '/api/users/{id}' do
+    # You'll want to customize the parameter types...
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show user') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    patch('update user') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    put('update user') do
+      response(200, 'successful') do
+        let(:id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/weathers_spec.rb
+++ b/backend/spec/requests/api/v1/weathers_spec.rb
@@ -2,7 +2,7 @@ require 'swagger_helper'
 
 RSpec.describe 'api/v1/weathers', type: :request do
   path '/api/weathers' do
-
+    pending("The weather API curretly doesn't work as expected, so not testing at this time")
     get('list weathers') do
       response(200, 'successful') do
 

--- a/backend/spec/requests/api/v1/weathers_spec.rb
+++ b/backend/spec/requests/api/v1/weathers_spec.rb
@@ -1,19 +1,18 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'api/v1/weathers', type: :request do
-  path '/api/weathers' do
+RSpec.describe "api/v1/weathers", type: :request do
+  path "/api/weathers" do
     pending("The weather API curretly doesn't work as expected, so not testing at this time")
-    get('list weathers') do
-      response(200, 'successful') do
-
+    get("list weathers") do
+      response(200, "successful") do
         after do |example|
           example.metadata[:response][:content] = {
-            'application/json' => {
+            "application/json" => {
               example: JSON.parse(response.body, symbolize_names: true)
             }
           }
         end
-         pending "Not yet implemented, when implemented uncomment the assertion below"
+        pending "Not yet implemented, when implemented uncomment the assertion below"
         # run_test!
       end
     end

--- a/backend/spec/requests/api/v1/weathers_spec.rb
+++ b/backend/spec/requests/api/v1/weathers_spec.rb
@@ -1,6 +1,7 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/weathers', type: :request do
+  before { sign_in create(:user) }
 
   path '/api/weathers' do
 

--- a/backend/spec/requests/api/v1/weathers_spec.rb
+++ b/backend/spec/requests/api/v1/weathers_spec.rb
@@ -1,0 +1,21 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/weathers', type: :request do
+
+  path '/api/weathers' do
+
+    get('list weathers') do
+      response(200, 'successful') do
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/weathers_spec.rb
+++ b/backend/spec/requests/api/v1/weathers_spec.rb
@@ -1,8 +1,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'api/v1/weathers', type: :request do
-  before { sign_in create(:user) }
-
   path '/api/weathers' do
 
     get('list weathers') do

--- a/backend/spec/requests/api/v1/weathers_spec.rb
+++ b/backend/spec/requests/api/v1/weathers_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'api/v1/weathers', type: :request do
             }
           }
         end
-        run_test!
+         pending "Not yet implemented, when implemented uncomment the assertion below"
+        # run_test!
       end
     end
   end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
   config.mock_with :rspec
 
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   config.infer_spec_type_from_file_location!
 

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join('swagger').to_s
+  config.swagger_root = Rails.root.join("swagger").to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
@@ -15,11 +15,11 @@ RSpec.configure do |config|
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.swagger_docs = {
-    'v1/swagger.yaml' => {
-      openapi: '3.0.1',
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
       info: {
-        title: 'API V1',
-        version: 'v1'
+        title: "API V1",
+        version: "v1"
       },
       paths: {},
       servers: [

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -24,10 +24,10 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: 'https://{defaultHost}',
+          url: 'http://{defaultHost}',
           variables: {
             defaultHost: {
-              default: 'www.example.com'
+              default: 'localhost:3000/'
             }
           }
         }

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -24,8 +24,8 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: 'http://localhost:3000',
-          description: 'local documentation'
+          url: "http://localhost:3000",
+          description: "local documentation"
         }
       ]
     }

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -24,12 +24,8 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: 'http://{defaultHost}',
-          variables: {
-            defaultHost: {
-              default: 'localhost:3000/'
-            }
-          }
+          url: 'http://localhost:3000',
+          description: 'local documentation'
         }
       ]
     }

--- a/backend/spec/swagger_helper.rb
+++ b/backend/spec/swagger_helper.rb
@@ -36,4 +36,8 @@ RSpec.configure do |config|
   # the key, this may want to be changed to avoid putting yaml in json files.
   # Defaults to json. Accepts ':json' and ':yaml'.
   config.swagger_format = :yaml
+
+  config.before(:each, type: :request) do
+    sign_in create(:user)
+  end
 end

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1,0 +1,52 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/symptoms/{id}":
+    get:
+      summary: show symptom
+      parameters:
+      - name: id
+        in: path
+        description: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  symptom:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        required: true
+                      updated_at:
+                        type: string
+                        required: true
+                      created_at:
+                        type: string
+                        required: true
+                      type:
+                        type: string
+                        required: true
+                      users_count:
+                        type: integer
+                        required: true
+                      name:
+                        type: string
+                        required: true
+                required:
+                - symptom
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -4,7 +4,103 @@ info:
   title: API V1
   version: v1
 paths:
-<<<<<<< HEAD
+  "/api/checkins":
+    get:
+      summary: list checkins
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: page'
+    post:
+      summary: create checkin
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: checkin'
+  "/api/checkins/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show checkin
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
+    patch:
+      summary: update checkin
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
+    put:
+      summary: update checkin
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
+  "/api/conditions":
+    get:
+      summary: list conditions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                conditions: []
+    post:
+      summary: create condition
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: condition'
+  "/api/conditions/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show condition
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/countries":
     get:
       summary: list countries
@@ -1031,91 +1127,47 @@ paths:
                   created_at:
                   updated_at:
                   name: United States
-||||||| parent of 64d8356f (Add swagger request specs for controllers and regenerate swagger file)
-=======
-  "/api/checkins":
-    get:
-      summary: list checkins
-      responses:
-        '200':
-          description: successful
-    post:
-      summary: create checkin
-      responses:
-        '200':
-          description: successful
-  "/api/checkins/{id}":
-    parameters:
-    - name: id
-      in: path
-      description: id
-      required: true
-      schema:
-        type: string
-    get:
-      summary: show checkin
-      responses:
-        '200':
-          description: successful
-    patch:
-      summary: update checkin
-      responses:
-        '200':
-          description: successful
-    put:
-      summary: update checkin
-      responses:
-        '200':
-          description: successful
-  "/api/conditions":
-    get:
-      summary: list conditions
-      responses:
-        '200':
-          description: successful
-    post:
-      summary: create condition
-      responses:
-        '200':
-          description: successful
-  "/api/conditions/{id}":
-    parameters:
-    - name: id
-      in: path
-      description: id
-      required: true
-      schema:
-        type: string
-    get:
-      summary: show condition
-      responses:
-        '200':
-          description: successful
-  "/api/countries":
-    get:
-      summary: list countries
-      responses:
-        '200':
-          description: successful
-  "/api/countries/{id}":
-    parameters:
-    - name: id
-      in: path
-      description: id
-      required: true
-      schema:
-        type: string
-    get:
-      summary: show country
-      responses:
-        '200':
-          description: successful
   "/api/day_habits":
     get:
       summary: list day_habits
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                day_habits:
+                - id: lying_down
+                  created_at:
+                  updated_at:
+                  name: Lying down
+                  rank: 1
+                  description: bedridden
+                - id: sitting_down
+                  created_at:
+                  updated_at:
+                  name: Sitting down or at a computer
+                  rank: 2
+                  description: e.g. student, programmer, architect
+                - id: on_feet
+                  created_at:
+                  updated_at:
+                  name: On your feet
+                  rank: 3
+                  description: e.g. physician, retail salesperson, tour guide
+                - id: driving
+                  created_at:
+                  updated_at:
+                  name: Driving around
+                  rank: 4
+                  description: e.g. pharmaceutical representative, taxi driver, truck
+                    driver
+                - id: working_with_hands
+                  created_at:
+                  updated_at:
+                  name: Working with your hands
+                  rank: 5
+                  description: e.g. farmer, fishery worker, landscaper
   "/api/day_habits/{id}":
     parameters:
     - name: id
@@ -1129,12 +1181,46 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Bad request: id param is not a valid day_habit id'
   "/api/education_levels":
     get:
       summary: list education_levels
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                education_levels:
+                - id: less_than_hi_school
+                  created_at:
+                  updated_at:
+                  name: Less than high school
+                  rank: 1
+                - id: hi_school
+                  created_at:
+                  updated_at:
+                  name: High school diploma
+                  rank: 2
+                - id: college_degree
+                  created_at:
+                  updated_at:
+                  name: Some college or associate's degree
+                  rank: 3
+                - id: bachelors_degree
+                  created_at:
+                  updated_at:
+                  name: Bachelor's degree
+                  rank: 4
+                - id: advanced_degree
+                  created_at:
+                  updated_at:
+                  name: Advanced degree
+                  rank: 5
   "/api/education_levels/{id}":
     parameters:
     - name: id
@@ -1148,12 +1234,76 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Bad request: id param is not a valid education_level id'
   "/api/ethnicities":
     get:
       summary: list ethnicities
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                ethnicities:
+                - id: latino
+                  created_at:
+                  updated_at:
+                  name: Latino or Hispanic
+                  rank: 1
+                - id: white
+                  created_at:
+                  updated_at:
+                  name: European or White
+                  rank: 2
+                - id: east_asian
+                  created_at:
+                  updated_at:
+                  name: East Asian
+                  rank: 3
+                - id: south_asian
+                  created_at:
+                  updated_at:
+                  name: South Asian
+                  rank: 4
+                - id: black
+                  created_at:
+                  updated_at:
+                  name: African American or Black
+                  rank: 5
+                - id: oceanian
+                  created_at:
+                  updated_at:
+                  name: Pacific Islander or Oceanian
+                  rank: 6
+                - id: middle_eastern
+                  created_at:
+                  updated_at:
+                  name: Middle Eastern or North African
+                  rank: 7
+                - id: native_american
+                  created_at:
+                  updated_at:
+                  name: Native American or Alaska Native
+                  rank: 8
+                - id: african
+                  created_at:
+                  updated_at:
+                  name: Sub-Saharan African
+                  rank: 9
+                - id: other
+                  created_at:
+                  updated_at:
+                  name: Other
+                  rank: 10
+                - id: not_sure
+                  created_at:
+                  updated_at:
+                  name: I'm not sure
+                  rank: 11
   "/api/ethnicities/{id}":
     parameters:
     - name: id
@@ -1167,12 +1317,22 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Bad request: id param is not a valid ethnicity id'
   "/api/passwords":
     post:
       summary: create password
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: password'
   "/api/passwords/{id}":
     parameters:
     - name: id
@@ -1186,27 +1346,58 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                password:
+                  id: '123'
+                  created_at: '2023-07-29T19:26:08.597Z'
+                  updated_at: '2023-07-29T19:26:08.608Z'
+                  email: user18@example.com
+                  reset_password_token: '123'
+                  current_password:
+                  password:
+                  password_confirmation:
     patch:
       summary: update password
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: password'
     put:
       summary: update password
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: password'
   "/api/posts":
     get:
       summary: list posts
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                posts: []
     post:
       summary: create post
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: post'
   "/api/posts/{id}":
     parameters:
     - name: id
@@ -1220,6 +1411,11 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/profiles":
     get:
       summary: list profiles
@@ -1239,40 +1435,94 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     patch:
       summary: update profile
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     put:
       summary: update profile
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/registrations/destroy":
     put:
       summary: delete registration
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
   "/api/registrations":
     post:
       summary: create registration
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: registration'
   "/api/searches":
     get:
       summary: show search
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                  resource:
+                  - can't be blank
+                  - is not included in the list
   "/api/sexes":
     get:
       summary: list sexes
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                sexes:
+                - id: male
+                  created_at:
+                  updated_at:
+                  name: Male
+                  rank: 1
+                - id: female
+                  created_at:
+                  updated_at:
+                  name: Female
+                  rank: 2
+                - id: other
+                  created_at:
+                  updated_at:
+                  name: Other
+                  rank: 3
+                - id: doesnt_say
+                  created_at:
+                  updated_at:
+                  name: Prefer not to say
+                  rank: 4
   "/api/sexes/{id}":
     parameters:
     - name: id
@@ -1286,7 +1536,11 @@ paths:
       responses:
         '200':
           description: successful
->>>>>>> 64d8356f (Add swagger request specs for controllers and regenerate swagger file)
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Bad request: id param is not a valid sex id'
   "/api/symptoms/{id}":
     get:
       summary: show symptom
@@ -1305,8 +1559,8 @@ paths:
               example:
                 symptom:
                   id: 1
-                  created_at: '2023-07-29T19:11:40.154Z'
-                  updated_at: '2023-07-29T19:11:40.154Z'
+                  created_at: '2023-07-29T19:26:09.396Z'
+                  updated_at: '2023-07-29T19:26:09.396Z'
                   type: symptom
                   color_id:
                   users_count: 0
@@ -1346,11 +1600,20 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                tags: []
     post:
       summary: create tag
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: tag'
   "/api/tags/{id}":
     parameters:
     - name: id
@@ -1364,17 +1627,32 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/trackings":
     get:
       summary: list trackings
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: trackable_type'
     post:
       summary: create tracking
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: tracking'
   "/api/trackings/{id}":
     parameters:
     - name: id
@@ -1388,22 +1666,41 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     delete:
       summary: delete tracking
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/treatments":
     get:
       summary: list treatments
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                treatments: []
     post:
       summary: create treatment
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: treatment'
   "/api/treatments/{id}":
     parameters:
     - name: id
@@ -1417,6 +1714,11 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/users/{id}":
     parameters:
     - name: id
@@ -1430,22 +1732,41 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     patch:
       summary: update user
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     put:
       summary: update user
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/weathers":
     get:
       summary: list weathers
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                weathers: []
 servers:
 - url: http://localhost:3000
   description: local documentation

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1048,8 +1048,8 @@ paths:
               example:
                 symptom:
                   id: 1
-                  created_at: '2023-07-29T19:11:40.154Z'
-                  updated_at: '2023-07-29T19:11:40.154Z'
+                  created_at: '2023-07-29T19:21:51.631Z'
+                  updated_at: '2023-07-29T19:21:51.631Z'
                   type: symptom
                   color_id:
                   users_count: 0

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -4,7 +4,103 @@ info:
   title: API V1
   version: v1
 paths:
-<<<<<<< HEAD
+  "/api/checkins":
+    get:
+      summary: list checkins
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: page'
+    post:
+      summary: create checkin
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: checkin'
+  "/api/checkins/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show checkin
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
+    patch:
+      summary: update checkin
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
+    put:
+      summary: update checkin
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
+  "/api/conditions":
+    get:
+      summary: list conditions
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                conditions: []
+    post:
+      summary: create condition
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: condition'
+  "/api/conditions/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show condition
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/countries":
     get:
       summary: list countries
@@ -1031,91 +1127,47 @@ paths:
                   created_at:
                   updated_at:
                   name: United States
-||||||| parent of 64d8356f (Add swagger request specs for controllers and regenerate swagger file)
-=======
-  "/api/checkins":
-    get:
-      summary: list checkins
-      responses:
-        '200':
-          description: successful
-    post:
-      summary: create checkin
-      responses:
-        '200':
-          description: successful
-  "/api/checkins/{id}":
-    parameters:
-    - name: id
-      in: path
-      description: id
-      required: true
-      schema:
-        type: string
-    get:
-      summary: show checkin
-      responses:
-        '200':
-          description: successful
-    patch:
-      summary: update checkin
-      responses:
-        '200':
-          description: successful
-    put:
-      summary: update checkin
-      responses:
-        '200':
-          description: successful
-  "/api/conditions":
-    get:
-      summary: list conditions
-      responses:
-        '200':
-          description: successful
-    post:
-      summary: create condition
-      responses:
-        '200':
-          description: successful
-  "/api/conditions/{id}":
-    parameters:
-    - name: id
-      in: path
-      description: id
-      required: true
-      schema:
-        type: string
-    get:
-      summary: show condition
-      responses:
-        '200':
-          description: successful
-  "/api/countries":
-    get:
-      summary: list countries
-      responses:
-        '200':
-          description: successful
-  "/api/countries/{id}":
-    parameters:
-    - name: id
-      in: path
-      description: id
-      required: true
-      schema:
-        type: string
-    get:
-      summary: show country
-      responses:
-        '200':
-          description: successful
   "/api/day_habits":
     get:
       summary: list day_habits
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                day_habits:
+                - id: lying_down
+                  created_at:
+                  updated_at:
+                  name: Lying down
+                  rank: 1
+                  description: bedridden
+                - id: sitting_down
+                  created_at:
+                  updated_at:
+                  name: Sitting down or at a computer
+                  rank: 2
+                  description: e.g. student, programmer, architect
+                - id: on_feet
+                  created_at:
+                  updated_at:
+                  name: On your feet
+                  rank: 3
+                  description: e.g. physician, retail salesperson, tour guide
+                - id: driving
+                  created_at:
+                  updated_at:
+                  name: Driving around
+                  rank: 4
+                  description: e.g. pharmaceutical representative, taxi driver, truck
+                    driver
+                - id: working_with_hands
+                  created_at:
+                  updated_at:
+                  name: Working with your hands
+                  rank: 5
+                  description: e.g. farmer, fishery worker, landscaper
   "/api/day_habits/{id}":
     parameters:
     - name: id
@@ -1129,12 +1181,46 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Bad request: id param is not a valid day_habit id'
   "/api/education_levels":
     get:
       summary: list education_levels
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                education_levels:
+                - id: less_than_hi_school
+                  created_at:
+                  updated_at:
+                  name: Less than high school
+                  rank: 1
+                - id: hi_school
+                  created_at:
+                  updated_at:
+                  name: High school diploma
+                  rank: 2
+                - id: college_degree
+                  created_at:
+                  updated_at:
+                  name: Some college or associate's degree
+                  rank: 3
+                - id: bachelors_degree
+                  created_at:
+                  updated_at:
+                  name: Bachelor's degree
+                  rank: 4
+                - id: advanced_degree
+                  created_at:
+                  updated_at:
+                  name: Advanced degree
+                  rank: 5
   "/api/education_levels/{id}":
     parameters:
     - name: id
@@ -1148,12 +1234,76 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Bad request: id param is not a valid education_level id'
   "/api/ethnicities":
     get:
       summary: list ethnicities
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                ethnicities:
+                - id: latino
+                  created_at:
+                  updated_at:
+                  name: Latino or Hispanic
+                  rank: 1
+                - id: white
+                  created_at:
+                  updated_at:
+                  name: European or White
+                  rank: 2
+                - id: east_asian
+                  created_at:
+                  updated_at:
+                  name: East Asian
+                  rank: 3
+                - id: south_asian
+                  created_at:
+                  updated_at:
+                  name: South Asian
+                  rank: 4
+                - id: black
+                  created_at:
+                  updated_at:
+                  name: African American or Black
+                  rank: 5
+                - id: oceanian
+                  created_at:
+                  updated_at:
+                  name: Pacific Islander or Oceanian
+                  rank: 6
+                - id: middle_eastern
+                  created_at:
+                  updated_at:
+                  name: Middle Eastern or North African
+                  rank: 7
+                - id: native_american
+                  created_at:
+                  updated_at:
+                  name: Native American or Alaska Native
+                  rank: 8
+                - id: african
+                  created_at:
+                  updated_at:
+                  name: Sub-Saharan African
+                  rank: 9
+                - id: other
+                  created_at:
+                  updated_at:
+                  name: Other
+                  rank: 10
+                - id: not_sure
+                  created_at:
+                  updated_at:
+                  name: I'm not sure
+                  rank: 11
   "/api/ethnicities/{id}":
     parameters:
     - name: id
@@ -1167,12 +1317,22 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Bad request: id param is not a valid ethnicity id'
   "/api/passwords":
     post:
       summary: create password
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: password'
   "/api/passwords/{id}":
     parameters:
     - name: id
@@ -1186,27 +1346,58 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                password:
+                  id: '123'
+                  created_at: '2023-07-29T19:26:08.597Z'
+                  updated_at: '2023-07-29T19:26:08.608Z'
+                  email: user18@example.com
+                  reset_password_token: '123'
+                  current_password:
+                  password:
+                  password_confirmation:
     patch:
       summary: update password
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: password'
     put:
       summary: update password
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: password'
   "/api/posts":
     get:
       summary: list posts
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                posts: []
     post:
       summary: create post
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: post'
   "/api/posts/{id}":
     parameters:
     - name: id
@@ -1220,6 +1411,11 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/profiles":
     get:
       summary: list profiles
@@ -1239,40 +1435,94 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     patch:
       summary: update profile
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     put:
       summary: update profile
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/registrations/destroy":
     put:
       summary: delete registration
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
   "/api/registrations":
     post:
       summary: create registration
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: registration'
   "/api/searches":
     get:
       summary: show search
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                  resource:
+                  - can't be blank
+                  - is not included in the list
   "/api/sexes":
     get:
       summary: list sexes
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                sexes:
+                - id: male
+                  created_at:
+                  updated_at:
+                  name: Male
+                  rank: 1
+                - id: female
+                  created_at:
+                  updated_at:
+                  name: Female
+                  rank: 2
+                - id: other
+                  created_at:
+                  updated_at:
+                  name: Other
+                  rank: 3
+                - id: doesnt_say
+                  created_at:
+                  updated_at:
+                  name: Prefer not to say
+                  rank: 4
   "/api/sexes/{id}":
     parameters:
     - name: id
@@ -1286,7 +1536,11 @@ paths:
       responses:
         '200':
           description: successful
->>>>>>> 64d8356f (Add swagger request specs for controllers and regenerate swagger file)
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Bad request: id param is not a valid sex id'
   "/api/symptoms/{id}":
     get:
       summary: show symptom
@@ -1346,11 +1600,20 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                tags: []
     post:
       summary: create tag
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: tag'
   "/api/tags/{id}":
     parameters:
     - name: id
@@ -1364,17 +1627,32 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/trackings":
     get:
       summary: list trackings
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: trackable_type'
     post:
       summary: create tracking
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: tracking'
   "/api/trackings/{id}":
     parameters:
     - name: id
@@ -1388,22 +1666,41 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     delete:
       summary: delete tracking
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/treatments":
     get:
       summary: list treatments
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                treatments: []
     post:
       summary: create treatment
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - 'Required parameter missing: treatment'
   "/api/treatments/{id}":
     parameters:
     - name: id
@@ -1417,6 +1714,11 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/users/{id}":
     parameters:
     - name: id
@@ -1430,22 +1732,41 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     patch:
       summary: update user
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
     put:
       summary: update user
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                errors:
+                - Resource Not Found
   "/api/weathers":
     get:
       summary: list weathers
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                weathers: []
 servers:
 - url: http://localhost:3000
   description: local documentation

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1351,8 +1351,8 @@ paths:
               example:
                 password:
                   id: '123'
-                  created_at: '2023-07-29T19:26:08.597Z'
-                  updated_at: '2023-07-29T19:26:08.608Z'
+                  created_at: '2023-07-29T21:16:17.837Z'
+                  updated_at: '2023-07-29T21:16:17.847Z'
                   email: user18@example.com
                   reset_password_token: '123'
                   current_password:
@@ -1559,8 +1559,8 @@ paths:
               example:
                 symptom:
                   id: 1
-                  created_at: '2023-07-29T19:26:09.396Z'
-                  updated_at: '2023-07-29T19:26:09.396Z'
+                  created_at: '2023-07-29T21:16:18.623Z'
+                  updated_at: '2023-07-29T21:16:18.623Z'
                   type: symptom
                   color_id:
                   users_count: 0
@@ -1735,18 +1735,92 @@ paths:
           content:
             application/json:
               example:
-                errors:
-                - Resource Not Found
+                user:
+                  id: 44
+                  created_at: '2023-07-29T21:16:19.276Z'
+                  updated_at: '2023-07-29T21:16:19.288Z'
+                  email: user44@example.com
+                  intercom_hash: 1b72b549ef1f8a6f2badcc28b160b8e42d547ea019a2e01a5e0cdec805cb1038
+                  topic_following_id: 64c581a30fabf06c40d60ded
+                  profile_id: 44
+                profiles:
+                - id: 44
+                  created_at: '2023-07-29T21:16:19.280Z'
+                  updated_at: '2023-07-29T21:16:19.280Z'
+                  screen_name:
+                  birth_date:
+                  country_id:
+                  sex_id:
+                  onboarding_step_id: onboarding-personal
+                  ethnicity_ids: []
+                  day_habit_id:
+                  education_level_id:
+                  day_walking_hours:
+                  pressure_units: mb
+                  temperature_units: f
+                  beta_tester: false
+                  notify_token: feb69ef67925d11393521bc5db6a2be2
+                  notify: true
+                  checkin_reminder: true
+                  checkin_reminder_at:
+                    hours: 20
+                    minutes: 0
+                  time_zone_name: America/New_York
+                  notify_top_posts: true
     patch:
       summary: update user
+      parameters: []
       responses:
         '200':
           description: successful
           content:
             application/json:
               example:
-                errors:
-                - Resource Not Found
+                user:
+                  id: 45
+                  created_at: '2023-07-29T21:16:19.345Z'
+                  updated_at: '2023-07-29T21:16:19.379Z'
+                  email: updatedemail@example.com
+                  intercom_hash: 7ab8b7681a8d33388b86b73953e0df9e6305458416f3a5293ca0ca37335a3328
+                  topic_following_id: 64c581a30fabf06c40d60dee
+                  profile_id: 45
+                profiles:
+                - id: 45
+                  created_at: '2023-07-29T21:16:19.349Z'
+                  updated_at: '2023-07-29T21:16:19.349Z'
+                  screen_name:
+                  birth_date:
+                  country_id:
+                  sex_id:
+                  onboarding_step_id: onboarding-personal
+                  ethnicity_ids: []
+                  day_habit_id:
+                  education_level_id:
+                  day_walking_hours:
+                  pressure_units: mb
+                  temperature_units: f
+                  beta_tester: false
+                  notify_token: 62ff91cef790c63fd310e939f1dec155
+                  notify: true
+                  checkin_reminder: true
+                  checkin_reminder_at:
+                    hours: 20
+                    minutes: 0
+                  time_zone_name: America/New_York
+                  notify_top_posts: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+              required:
+              - user
     put:
       summary: update user
       responses:
@@ -1756,7 +1830,7 @@ paths:
             application/json:
               example:
                 errors:
-                - Resource Not Found
+                - 'Required parameter missing: user'
   "/api/weathers":
     get:
       summary: list weathers

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -4,6 +4,1032 @@ info:
   title: API V1
   version: v1
 paths:
+  "/api/countries":
+    get:
+      summary: list countries
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+              - id: TJ
+                created_at:
+                updated_at:
+                name: Tajikistan
+              - id: JM
+                created_at:
+                updated_at:
+                name: Jamaica
+              - id: HT
+                created_at:
+                updated_at:
+                name: Haiti
+              - id: ST
+                created_at:
+                updated_at:
+                name: Sao Tome and Principe
+              - id: MS
+                created_at:
+                updated_at:
+                name: Montserrat
+              - id: AE
+                created_at:
+                updated_at:
+                name: United Arab Emirates
+              - id: PK
+                created_at:
+                updated_at:
+                name: Pakistan
+              - id: NL
+                created_at:
+                updated_at:
+                name: Netherlands
+              - id: LU
+                created_at:
+                updated_at:
+                name: Luxembourg
+              - id: BZ
+                created_at:
+                updated_at:
+                name: Belize
+              - id: IR
+                created_at:
+                updated_at:
+                name: Iran, Islamic Republic of
+              - id: BO
+                created_at:
+                updated_at:
+                name: Bolivia
+              - id: UY
+                created_at:
+                updated_at:
+                name: Uruguay
+              - id: GH
+                created_at:
+                updated_at:
+                name: Ghana
+              - id: SA
+                created_at:
+                updated_at:
+                name: Saudi Arabia
+              - id: CI
+                created_at:
+                updated_at:
+                name: Côte d'Ivoire
+              - id: MF
+                created_at:
+                updated_at:
+                name: Saint Martin (French part)
+              - id: TF
+                created_at:
+                updated_at:
+                name: French Southern Territories
+              - id: AI
+                created_at:
+                updated_at:
+                name: Anguilla
+              - id: QA
+                created_at:
+                updated_at:
+                name: Qatar
+              - id: SX
+                created_at:
+                updated_at:
+                name: Sint Maarten (Dutch part)
+              - id: LY
+                created_at:
+                updated_at:
+                name: Libya
+              - id: BV
+                created_at:
+                updated_at:
+                name: Bouvet Island
+              - id: PG
+                created_at:
+                updated_at:
+                name: Papua New Guinea
+              - id: KG
+                created_at:
+                updated_at:
+                name: Kyrgyzstan
+              - id: GQ
+                created_at:
+                updated_at:
+                name: Equatorial Guinea
+              - id: EH
+                created_at:
+                updated_at:
+                name: Western Sahara
+              - id: NU
+                created_at:
+                updated_at:
+                name: Niue
+              - id: PR
+                created_at:
+                updated_at:
+                name: Puerto Rico
+              - id: GD
+                created_at:
+                updated_at:
+                name: Grenada
+              - id: KR
+                created_at:
+                updated_at:
+                name: Korea, Republic of
+              - id: HM
+                created_at:
+                updated_at:
+                name: Heard Island and McDonald Islands
+              - id: SM
+                created_at:
+                updated_at:
+                name: San Marino
+              - id: SL
+                created_at:
+                updated_at:
+                name: Sierra Leone
+              - id: CD
+                created_at:
+                updated_at:
+                name: Congo, The Democratic Republic of the
+              - id: MK
+                created_at:
+                updated_at:
+                name: North Macedonia
+              - id: TR
+                created_at:
+                updated_at:
+                name: Turkey
+              - id: DZ
+                created_at:
+                updated_at:
+                name: Algeria
+              - id: GE
+                created_at:
+                updated_at:
+                name: Georgia
+              - id: PS
+                created_at:
+                updated_at:
+                name: Palestine, State of
+              - id: BB
+                created_at:
+                updated_at:
+                name: Barbados
+              - id: UA
+                created_at:
+                updated_at:
+                name: Ukraine
+              - id: GP
+                created_at:
+                updated_at:
+                name: Guadeloupe
+              - id: PF
+                created_at:
+                updated_at:
+                name: French Polynesia
+              - id: NA
+                created_at:
+                updated_at:
+                name: Namibia
+              - id: BW
+                created_at:
+                updated_at:
+                name: Botswana
+              - id: SY
+                created_at:
+                updated_at:
+                name: Syrian Arab Republic
+              - id: TG
+                created_at:
+                updated_at:
+                name: Togo
+              - id: DO
+                created_at:
+                updated_at:
+                name: Dominican Republic
+              - id: AQ
+                created_at:
+                updated_at:
+                name: Antarctica
+              - id: CH
+                created_at:
+                updated_at:
+                name: Switzerland
+              - id: MG
+                created_at:
+                updated_at:
+                name: Madagascar
+              - id: FO
+                created_at:
+                updated_at:
+                name: Faroe Islands
+              - id: VG
+                created_at:
+                updated_at:
+                name: Virgin Islands, British
+              - id: GI
+                created_at:
+                updated_at:
+                name: Gibraltar
+              - id: BN
+                created_at:
+                updated_at:
+                name: Brunei Darussalam
+              - id: LA
+                created_at:
+                updated_at:
+                name: Lao People's Democratic Republic
+              - id: IS
+                created_at:
+                updated_at:
+                name: Iceland
+              - id: EE
+                created_at:
+                updated_at:
+                name: Estonia
+              - id: UM
+                created_at:
+                updated_at:
+                name: United States Minor Outlying Islands
+              - id: LT
+                created_at:
+                updated_at:
+                name: Lithuania
+              - id: RS
+                created_at:
+                updated_at:
+                name: Serbia
+              - id: MR
+                created_at:
+                updated_at:
+                name: Mauritania
+              - id: AD
+                created_at:
+                updated_at:
+                name: Andorra
+              - id: HU
+                created_at:
+                updated_at:
+                name: Hungary
+              - id: TK
+                created_at:
+                updated_at:
+                name: Tokelau
+              - id: MY
+                created_at:
+                updated_at:
+                name: Malaysia
+              - id: AO
+                created_at:
+                updated_at:
+                name: Angola
+              - id: CV
+                created_at:
+                updated_at:
+                name: Cabo Verde
+              - id: NF
+                created_at:
+                updated_at:
+                name: Norfolk Island
+              - id: PA
+                created_at:
+                updated_at:
+                name: Panama
+              - id: GW
+                created_at:
+                updated_at:
+                name: Guinea-Bissau
+              - id: BE
+                created_at:
+                updated_at:
+                name: Belgium
+              - id: PT
+                created_at:
+                updated_at:
+                name: Portugal
+              - id: GB
+                created_at:
+                updated_at:
+                name: United Kingdom
+              - id: IM
+                created_at:
+                updated_at:
+                name: Isle of Man
+              - id: US
+                created_at:
+                updated_at:
+                name: United States
+              - id: YE
+                created_at:
+                updated_at:
+                name: Yemen
+              - id: HK
+                created_at:
+                updated_at:
+                name: Hong Kong
+              - id: AZ
+                created_at:
+                updated_at:
+                name: Azerbaijan
+              - id: CC
+                created_at:
+                updated_at:
+                name: Cocos (Keeling) Islands
+              - id: ML
+                created_at:
+                updated_at:
+                name: Mali
+              - id: SK
+                created_at:
+                updated_at:
+                name: Slovakia
+              - id: VU
+                created_at:
+                updated_at:
+                name: Vanuatu
+              - id: TL
+                created_at:
+                updated_at:
+                name: Timor-Leste
+              - id: HR
+                created_at:
+                updated_at:
+                name: Croatia
+              - id: SR
+                created_at:
+                updated_at:
+                name: Suriname
+              - id: MU
+                created_at:
+                updated_at:
+                name: Mauritius
+              - id: CZ
+                created_at:
+                updated_at:
+                name: Czechia
+              - id: PM
+                created_at:
+                updated_at:
+                name: Saint Pierre and Miquelon
+              - id: LS
+                created_at:
+                updated_at:
+                name: Lesotho
+              - id: WS
+                created_at:
+                updated_at:
+                name: Samoa
+              - id: KM
+                created_at:
+                updated_at:
+                name: Comoros
+              - id: IT
+                created_at:
+                updated_at:
+                name: Italy
+              - id: BI
+                created_at:
+                updated_at:
+                name: Burundi
+              - id: WF
+                created_at:
+                updated_at:
+                name: Wallis and Futuna
+              - id: GN
+                created_at:
+                updated_at:
+                name: Guinea
+              - id: SG
+                created_at:
+                updated_at:
+                name: Singapore
+              - id: CO
+                created_at:
+                updated_at:
+                name: Colombia
+              - id: CN
+                created_at:
+                updated_at:
+                name: China
+              - id: AW
+                created_at:
+                updated_at:
+                name: Aruba
+              - id: MA
+                created_at:
+                updated_at:
+                name: Morocco
+              - id: FI
+                created_at:
+                updated_at:
+                name: Finland
+              - id: VA
+                created_at:
+                updated_at:
+                name: Holy See (Vatican City State)
+              - id: ZW
+                created_at:
+                updated_at:
+                name: Zimbabwe
+              - id: KY
+                created_at:
+                updated_at:
+                name: Cayman Islands
+              - id: BH
+                created_at:
+                updated_at:
+                name: Bahrain
+              - id: PY
+                created_at:
+                updated_at:
+                name: Paraguay
+              - id: EC
+                created_at:
+                updated_at:
+                name: Ecuador
+              - id: LR
+                created_at:
+                updated_at:
+                name: Liberia
+              - id: RU
+                created_at:
+                updated_at:
+                name: Russian Federation
+              - id: PL
+                created_at:
+                updated_at:
+                name: Poland
+              - id: OM
+                created_at:
+                updated_at:
+                name: Oman
+              - id: MT
+                created_at:
+                updated_at:
+                name: Malta
+              - id: SS
+                created_at:
+                updated_at:
+                name: South Sudan
+              - id: DE
+                created_at:
+                updated_at:
+                name: Germany
+              - id: TM
+                created_at:
+                updated_at:
+                name: Turkmenistan
+              - id: SJ
+                created_at:
+                updated_at:
+                name: Svalbard and Jan Mayen
+              - id: MM
+                created_at:
+                updated_at:
+                name: Myanmar
+              - id: TT
+                created_at:
+                updated_at:
+                name: Trinidad and Tobago
+              - id: IL
+                created_at:
+                updated_at:
+                name: Israel
+              - id: BD
+                created_at:
+                updated_at:
+                name: Bangladesh
+              - id: NR
+                created_at:
+                updated_at:
+                name: Nauru
+              - id: LK
+                created_at:
+                updated_at:
+                name: Sri Lanka
+              - id: UG
+                created_at:
+                updated_at:
+                name: Uganda
+              - id: NG
+                created_at:
+                updated_at:
+                name: Nigeria
+              - id: BQ
+                created_at:
+                updated_at:
+                name: Bonaire, Sint Eustatius and Saba
+              - id: MX
+                created_at:
+                updated_at:
+                name: Mexico
+              - id: CW
+                created_at:
+                updated_at:
+                name: Curaçao
+              - id: SI
+                created_at:
+                updated_at:
+                name: Slovenia
+              - id: MN
+                created_at:
+                updated_at:
+                name: Mongolia
+              - id: CA
+                created_at:
+                updated_at:
+                name: Canada
+              - id: AX
+                created_at:
+                updated_at:
+                name: Åland Islands
+              - id: VN
+                created_at:
+                updated_at:
+                name: Vietnam
+              - id: TW
+                created_at:
+                updated_at:
+                name: Taiwan
+              - id: JP
+                created_at:
+                updated_at:
+                name: Japan
+              - id: IO
+                created_at:
+                updated_at:
+                name: British Indian Ocean Territory
+              - id: RO
+                created_at:
+                updated_at:
+                name: Romania
+              - id: BG
+                created_at:
+                updated_at:
+                name: Bulgaria
+              - id: GU
+                created_at:
+                updated_at:
+                name: Guam
+              - id: BR
+                created_at:
+                updated_at:
+                name: Brazil
+              - id: AM
+                created_at:
+                updated_at:
+                name: Armenia
+              - id: ZM
+                created_at:
+                updated_at:
+                name: Zambia
+              - id: DJ
+                created_at:
+                updated_at:
+                name: Djibouti
+              - id: JE
+                created_at:
+                updated_at:
+                name: Jersey
+              - id: AT
+                created_at:
+                updated_at:
+                name: Austria
+              - id: CM
+                created_at:
+                updated_at:
+                name: Cameroon
+              - id: SE
+                created_at:
+                updated_at:
+                name: Sweden
+              - id: FJ
+                created_at:
+                updated_at:
+                name: Fiji
+              - id: KZ
+                created_at:
+                updated_at:
+                name: Kazakhstan
+              - id: GL
+                created_at:
+                updated_at:
+                name: Greenland
+              - id: GY
+                created_at:
+                updated_at:
+                name: Guyana
+              - id: CX
+                created_at:
+                updated_at:
+                name: Christmas Island
+              - id: MW
+                created_at:
+                updated_at:
+                name: Malawi
+              - id: TN
+                created_at:
+                updated_at:
+                name: Tunisia
+              - id: ZA
+                created_at:
+                updated_at:
+                name: South Africa
+              - id: TO
+                created_at:
+                updated_at:
+                name: Tonga
+              - id: CY
+                created_at:
+                updated_at:
+                name: Cyprus
+              - id: MV
+                created_at:
+                updated_at:
+                name: Maldives
+              - id: PN
+                created_at:
+                updated_at:
+                name: Pitcairn
+              - id: RW
+                created_at:
+                updated_at:
+                name: Rwanda
+              - id: NI
+                created_at:
+                updated_at:
+                name: Nicaragua
+              - id: KN
+                created_at:
+                updated_at:
+                name: Saint Kitts and Nevis
+              - id: BJ
+                created_at:
+                updated_at:
+                name: Benin
+              - id: ET
+                created_at:
+                updated_at:
+                name: Ethiopia
+              - id: GM
+                created_at:
+                updated_at:
+                name: Gambia
+              - id: TZ
+                created_at:
+                updated_at:
+                name: Tanzania
+              - id: VC
+                created_at:
+                updated_at:
+                name: Saint Vincent and the Grenadines
+              - id: FK
+                created_at:
+                updated_at:
+                name: Falkland Islands (Malvinas)
+              - id: SD
+                created_at:
+                updated_at:
+                name: Sudan
+              - id: MC
+                created_at:
+                updated_at:
+                name: Monaco
+              - id: AU
+                created_at:
+                updated_at:
+                name: Australia
+              - id: CL
+                created_at:
+                updated_at:
+                name: Chile
+              - id: DK
+                created_at:
+                updated_at:
+                name: Denmark
+              - id: FR
+                created_at:
+                updated_at:
+                name: France
+              - id: TC
+                created_at:
+                updated_at:
+                name: Turks and Caicos Islands
+              - id: CU
+                created_at:
+                updated_at:
+                name: Cuba
+              - id: AL
+                created_at:
+                updated_at:
+                name: Albania
+              - id: MZ
+                created_at:
+                updated_at:
+                name: Mozambique
+              - id: BS
+                created_at:
+                updated_at:
+                name: Bahamas
+              - id: NE
+                created_at:
+                updated_at:
+                name: Niger
+              - id: GT
+                created_at:
+                updated_at:
+                name: Guatemala
+              - id: LI
+                created_at:
+                updated_at:
+                name: Liechtenstein
+              - id: NP
+                created_at:
+                updated_at:
+                name: Nepal
+              - id: BF
+                created_at:
+                updated_at:
+                name: Burkina Faso
+              - id: PW
+                created_at:
+                updated_at:
+                name: Palau
+              - id: KW
+                created_at:
+                updated_at:
+                name: Kuwait
+              - id: IN
+                created_at:
+                updated_at:
+                name: India
+              - id: GA
+                created_at:
+                updated_at:
+                name: Gabon
+              - id: TV
+                created_at:
+                updated_at:
+                name: Tuvalu
+              - id: MO
+                created_at:
+                updated_at:
+                name: Macao
+              - id: SH
+                created_at:
+                updated_at:
+                name: Saint Helena, Ascension and Tristan da Cunha
+              - id: MD
+                created_at:
+                updated_at:
+                name: Moldova
+              - id: CK
+                created_at:
+                updated_at:
+                name: Cook Islands
+              - id: AR
+                created_at:
+                updated_at:
+                name: Argentina
+              - id: SC
+                created_at:
+                updated_at:
+                name: Seychelles
+              - id: IE
+                created_at:
+                updated_at:
+                name: Ireland
+              - id: ES
+                created_at:
+                updated_at:
+                name: Spain
+              - id: LB
+                created_at:
+                updated_at:
+                name: Lebanon
+              - id: BM
+                created_at:
+                updated_at:
+                name: Bermuda
+              - id: RE
+                created_at:
+                updated_at:
+                name: Réunion
+              - id: KI
+                created_at:
+                updated_at:
+                name: Kiribati
+              - id: AG
+                created_at:
+                updated_at:
+                name: Antigua and Barbuda
+              - id: MQ
+                created_at:
+                updated_at:
+                name: Martinique
+              - id: SV
+                created_at:
+                updated_at:
+                name: El Salvador
+              - id: JO
+                created_at:
+                updated_at:
+                name: Jordan
+              - id: TH
+                created_at:
+                updated_at:
+                name: Thailand
+              - id: SO
+                created_at:
+                updated_at:
+                name: Somalia
+              - id: MH
+                created_at:
+                updated_at:
+                name: Marshall Islands
+              - id: CG
+                created_at:
+                updated_at:
+                name: Congo
+              - id: KP
+                created_at:
+                updated_at:
+                name: Korea, Democratic People's Republic of
+              - id: GF
+                created_at:
+                updated_at:
+                name: French Guiana
+              - id: BA
+                created_at:
+                updated_at:
+                name: Bosnia and Herzegovina
+              - id: YT
+                created_at:
+                updated_at:
+                name: Mayotte
+              - id: GS
+                created_at:
+                updated_at:
+                name: South Georgia and the South Sandwich Islands
+              - id: KE
+                created_at:
+                updated_at:
+                name: Kenya
+              - id: PE
+                created_at:
+                updated_at:
+                name: Peru
+              - id: BT
+                created_at:
+                updated_at:
+                name: Bhutan
+              - id: SZ
+                created_at:
+                updated_at:
+                name: Eswatini
+              - id: CR
+                created_at:
+                updated_at:
+                name: Costa Rica
+              - id: TD
+                created_at:
+                updated_at:
+                name: Chad
+              - id: DM
+                created_at:
+                updated_at:
+                name: Dominica
+              - id: NC
+                created_at:
+                updated_at:
+                name: New Caledonia
+              - id: GR
+                created_at:
+                updated_at:
+                name: Greece
+              - id: GG
+                created_at:
+                updated_at:
+                name: Guernsey
+              - id: HN
+                created_at:
+                updated_at:
+                name: Honduras
+              - id: VI
+                created_at:
+                updated_at:
+                name: Virgin Islands, U.S.
+              - id: CF
+                created_at:
+                updated_at:
+                name: Central African Republic
+              - id: SN
+                created_at:
+                updated_at:
+                name: Senegal
+              - id: AF
+                created_at:
+                updated_at:
+                name: Afghanistan
+              - id: MP
+                created_at:
+                updated_at:
+                name: Northern Mariana Islands
+              - id: PH
+                created_at:
+                updated_at:
+                name: Philippines
+              - id: BY
+                created_at:
+                updated_at:
+                name: Belarus
+              - id: LV
+                created_at:
+                updated_at:
+                name: Latvia
+              - id: 'NO'
+                created_at:
+                updated_at:
+                name: Norway
+              - id: EG
+                created_at:
+                updated_at:
+                name: Egypt
+              - id: KH
+                created_at:
+                updated_at:
+                name: Cambodia
+              - id: IQ
+                created_at:
+                updated_at:
+                name: Iraq
+              - id: LC
+                created_at:
+                updated_at:
+                name: Saint Lucia
+              - id: NZ
+                created_at:
+                updated_at:
+                name: New Zealand
+              - id: BL
+                created_at:
+                updated_at:
+                name: Saint Barthélemy
+              - id: UZ
+                created_at:
+                updated_at:
+                name: Uzbekistan
+              - id: ID
+                created_at:
+                updated_at:
+                name: Indonesia
+              - id: ER
+                created_at:
+                updated_at:
+                name: Eritrea
+              - id: VE
+                created_at:
+                updated_at:
+                name: Venezuela
+              - id: FM
+                created_at:
+                updated_at:
+                name: Micronesia, Federated States of
+              - id: SB
+                created_at:
+                updated_at:
+                name: Solomon Islands
+              - id: ME
+                created_at:
+                updated_at:
+                name: Montenegro
+              - id: AS
+                created_at:
+                updated_at:
+                name: American Samoa
+  "/api/countries/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show country
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                country:
+                  id: US
+                  created_at:
+                  updated_at:
+                  name: United States
   "/api/symptoms/{id}":
     get:
       summary: show symptom
@@ -19,6 +1045,15 @@ paths:
           description: successful
           content:
             application/json:
+              example:
+                symptom:
+                  id: 1
+                  created_at: '2023-07-29T19:11:40.154Z'
+                  updated_at: '2023-07-29T19:11:40.154Z'
+                  type: symptom
+                  color_id:
+                  users_count: 0
+                  name: Symptom1
               schema:
                 type: object
                 properties:
@@ -37,6 +1072,9 @@ paths:
                       type:
                         type: string
                         required: true
+                      color_id:
+                        type: integer
+                        nullable: true
                       users_count:
                         type: integer
                         required: true
@@ -46,7 +1084,5 @@ paths:
                 required:
                 - symptom
 servers:
-- url: https://{defaultHost}
-  variables:
-    defaultHost:
-      default: www.example.com
+- url: http://localhost:3000
+  description: local documentation

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1351,8 +1351,8 @@ paths:
               example:
                 password:
                   id: '123'
-                  created_at: '2023-07-29T21:16:17.837Z'
-                  updated_at: '2023-07-29T21:16:17.847Z'
+                  created_at: '2023-07-29T22:44:52.661Z'
+                  updated_at: '2023-07-29T22:44:52.671Z'
                   email: user18@example.com
                   reset_password_token: '123'
                   current_password:
@@ -1559,8 +1559,8 @@ paths:
               example:
                 symptom:
                   id: 1
-                  created_at: '2023-07-29T21:16:18.623Z'
-                  updated_at: '2023-07-29T21:16:18.623Z'
+                  created_at: '2023-07-29T22:44:53.365Z'
+                  updated_at: '2023-07-29T22:44:53.365Z'
                   type: symptom
                   color_id:
                   users_count: 0
@@ -1737,16 +1737,16 @@ paths:
               example:
                 user:
                   id: 44
-                  created_at: '2023-07-29T21:16:19.276Z'
-                  updated_at: '2023-07-29T21:16:19.288Z'
+                  created_at: '2023-07-29T22:44:53.954Z'
+                  updated_at: '2023-07-29T22:44:53.966Z'
                   email: user44@example.com
                   intercom_hash: 1b72b549ef1f8a6f2badcc28b160b8e42d547ea019a2e01a5e0cdec805cb1038
-                  topic_following_id: 64c581a30fabf06c40d60ded
+                  topic_following_id: 64c596650fabf076afb69632
                   profile_id: 44
                 profiles:
                 - id: 44
-                  created_at: '2023-07-29T21:16:19.280Z'
-                  updated_at: '2023-07-29T21:16:19.280Z'
+                  created_at: '2023-07-29T22:44:53.958Z'
+                  updated_at: '2023-07-29T22:44:53.958Z'
                   screen_name:
                   birth_date:
                   country_id:
@@ -1759,7 +1759,7 @@ paths:
                   pressure_units: mb
                   temperature_units: f
                   beta_tester: false
-                  notify_token: feb69ef67925d11393521bc5db6a2be2
+                  notify_token: 436550160eed6aa631b6947f8c84ed89
                   notify: true
                   checkin_reminder: true
                   checkin_reminder_at:
@@ -1778,16 +1778,16 @@ paths:
               example:
                 user:
                   id: 45
-                  created_at: '2023-07-29T21:16:19.345Z'
-                  updated_at: '2023-07-29T21:16:19.379Z'
+                  created_at: '2023-07-29T22:44:54.029Z'
+                  updated_at: '2023-07-29T22:44:54.066Z'
                   email: updatedemail@example.com
                   intercom_hash: 7ab8b7681a8d33388b86b73953e0df9e6305458416f3a5293ca0ca37335a3328
-                  topic_following_id: 64c581a30fabf06c40d60dee
+                  topic_following_id: 64c596660fabf076afb69633
                   profile_id: 45
                 profiles:
                 - id: 45
-                  created_at: '2023-07-29T21:16:19.349Z'
-                  updated_at: '2023-07-29T21:16:19.349Z'
+                  created_at: '2023-07-29T22:44:54.032Z'
+                  updated_at: '2023-07-29T22:44:54.032Z'
                   screen_name:
                   birth_date:
                   country_id:
@@ -1800,7 +1800,7 @@ paths:
                   pressure_units: mb
                   temperature_units: f
                   beta_tester: false
-                  notify_token: 62ff91cef790c63fd310e939f1dec155
+                  notify_token: 743ad1a9a5340b98725f5f3e343c9bec
                   notify: true
                   checkin_reminder: true
                   checkin_reminder_at:
@@ -1821,6 +1821,12 @@ paths:
                       type: string
               required:
               - user
+            examples:
+              request_example_1:
+                summary: A request example
+                value:
+                  user:
+                    email: updatedemail@example.com
     put:
       summary: update user
       responses:

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -68,6 +68,1006 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                countries:
+                - id: TJ
+                  created_at:
+                  updated_at:
+                  name: Tajikistan
+                - id: JM
+                  created_at:
+                  updated_at:
+                  name: Jamaica
+                - id: HT
+                  created_at:
+                  updated_at:
+                  name: Haiti
+                - id: ST
+                  created_at:
+                  updated_at:
+                  name: Sao Tome and Principe
+                - id: MS
+                  created_at:
+                  updated_at:
+                  name: Montserrat
+                - id: AE
+                  created_at:
+                  updated_at:
+                  name: United Arab Emirates
+                - id: PK
+                  created_at:
+                  updated_at:
+                  name: Pakistan
+                - id: NL
+                  created_at:
+                  updated_at:
+                  name: Netherlands
+                - id: LU
+                  created_at:
+                  updated_at:
+                  name: Luxembourg
+                - id: BZ
+                  created_at:
+                  updated_at:
+                  name: Belize
+                - id: IR
+                  created_at:
+                  updated_at:
+                  name: Iran, Islamic Republic of
+                - id: BO
+                  created_at:
+                  updated_at:
+                  name: Bolivia
+                - id: UY
+                  created_at:
+                  updated_at:
+                  name: Uruguay
+                - id: GH
+                  created_at:
+                  updated_at:
+                  name: Ghana
+                - id: SA
+                  created_at:
+                  updated_at:
+                  name: Saudi Arabia
+                - id: CI
+                  created_at:
+                  updated_at:
+                  name: Côte d'Ivoire
+                - id: MF
+                  created_at:
+                  updated_at:
+                  name: Saint Martin (French part)
+                - id: TF
+                  created_at:
+                  updated_at:
+                  name: French Southern Territories
+                - id: AI
+                  created_at:
+                  updated_at:
+                  name: Anguilla
+                - id: QA
+                  created_at:
+                  updated_at:
+                  name: Qatar
+                - id: SX
+                  created_at:
+                  updated_at:
+                  name: Sint Maarten (Dutch part)
+                - id: LY
+                  created_at:
+                  updated_at:
+                  name: Libya
+                - id: BV
+                  created_at:
+                  updated_at:
+                  name: Bouvet Island
+                - id: PG
+                  created_at:
+                  updated_at:
+                  name: Papua New Guinea
+                - id: KG
+                  created_at:
+                  updated_at:
+                  name: Kyrgyzstan
+                - id: GQ
+                  created_at:
+                  updated_at:
+                  name: Equatorial Guinea
+                - id: EH
+                  created_at:
+                  updated_at:
+                  name: Western Sahara
+                - id: NU
+                  created_at:
+                  updated_at:
+                  name: Niue
+                - id: PR
+                  created_at:
+                  updated_at:
+                  name: Puerto Rico
+                - id: GD
+                  created_at:
+                  updated_at:
+                  name: Grenada
+                - id: KR
+                  created_at:
+                  updated_at:
+                  name: Korea, Republic of
+                - id: HM
+                  created_at:
+                  updated_at:
+                  name: Heard Island and McDonald Islands
+                - id: SM
+                  created_at:
+                  updated_at:
+                  name: San Marino
+                - id: SL
+                  created_at:
+                  updated_at:
+                  name: Sierra Leone
+                - id: CD
+                  created_at:
+                  updated_at:
+                  name: Congo, The Democratic Republic of the
+                - id: MK
+                  created_at:
+                  updated_at:
+                  name: North Macedonia
+                - id: TR
+                  created_at:
+                  updated_at:
+                  name: Turkey
+                - id: DZ
+                  created_at:
+                  updated_at:
+                  name: Algeria
+                - id: GE
+                  created_at:
+                  updated_at:
+                  name: Georgia
+                - id: PS
+                  created_at:
+                  updated_at:
+                  name: Palestine, State of
+                - id: BB
+                  created_at:
+                  updated_at:
+                  name: Barbados
+                - id: UA
+                  created_at:
+                  updated_at:
+                  name: Ukraine
+                - id: GP
+                  created_at:
+                  updated_at:
+                  name: Guadeloupe
+                - id: PF
+                  created_at:
+                  updated_at:
+                  name: French Polynesia
+                - id: NA
+                  created_at:
+                  updated_at:
+                  name: Namibia
+                - id: BW
+                  created_at:
+                  updated_at:
+                  name: Botswana
+                - id: SY
+                  created_at:
+                  updated_at:
+                  name: Syrian Arab Republic
+                - id: TG
+                  created_at:
+                  updated_at:
+                  name: Togo
+                - id: DO
+                  created_at:
+                  updated_at:
+                  name: Dominican Republic
+                - id: AQ
+                  created_at:
+                  updated_at:
+                  name: Antarctica
+                - id: CH
+                  created_at:
+                  updated_at:
+                  name: Switzerland
+                - id: MG
+                  created_at:
+                  updated_at:
+                  name: Madagascar
+                - id: FO
+                  created_at:
+                  updated_at:
+                  name: Faroe Islands
+                - id: VG
+                  created_at:
+                  updated_at:
+                  name: Virgin Islands, British
+                - id: GI
+                  created_at:
+                  updated_at:
+                  name: Gibraltar
+                - id: BN
+                  created_at:
+                  updated_at:
+                  name: Brunei Darussalam
+                - id: LA
+                  created_at:
+                  updated_at:
+                  name: Lao People's Democratic Republic
+                - id: IS
+                  created_at:
+                  updated_at:
+                  name: Iceland
+                - id: EE
+                  created_at:
+                  updated_at:
+                  name: Estonia
+                - id: UM
+                  created_at:
+                  updated_at:
+                  name: United States Minor Outlying Islands
+                - id: LT
+                  created_at:
+                  updated_at:
+                  name: Lithuania
+                - id: RS
+                  created_at:
+                  updated_at:
+                  name: Serbia
+                - id: MR
+                  created_at:
+                  updated_at:
+                  name: Mauritania
+                - id: AD
+                  created_at:
+                  updated_at:
+                  name: Andorra
+                - id: HU
+                  created_at:
+                  updated_at:
+                  name: Hungary
+                - id: TK
+                  created_at:
+                  updated_at:
+                  name: Tokelau
+                - id: MY
+                  created_at:
+                  updated_at:
+                  name: Malaysia
+                - id: AO
+                  created_at:
+                  updated_at:
+                  name: Angola
+                - id: CV
+                  created_at:
+                  updated_at:
+                  name: Cabo Verde
+                - id: NF
+                  created_at:
+                  updated_at:
+                  name: Norfolk Island
+                - id: PA
+                  created_at:
+                  updated_at:
+                  name: Panama
+                - id: GW
+                  created_at:
+                  updated_at:
+                  name: Guinea-Bissau
+                - id: BE
+                  created_at:
+                  updated_at:
+                  name: Belgium
+                - id: PT
+                  created_at:
+                  updated_at:
+                  name: Portugal
+                - id: GB
+                  created_at:
+                  updated_at:
+                  name: United Kingdom
+                - id: IM
+                  created_at:
+                  updated_at:
+                  name: Isle of Man
+                - id: US
+                  created_at:
+                  updated_at:
+                  name: United States
+                - id: YE
+                  created_at:
+                  updated_at:
+                  name: Yemen
+                - id: HK
+                  created_at:
+                  updated_at:
+                  name: Hong Kong
+                - id: AZ
+                  created_at:
+                  updated_at:
+                  name: Azerbaijan
+                - id: CC
+                  created_at:
+                  updated_at:
+                  name: Cocos (Keeling) Islands
+                - id: ML
+                  created_at:
+                  updated_at:
+                  name: Mali
+                - id: SK
+                  created_at:
+                  updated_at:
+                  name: Slovakia
+                - id: VU
+                  created_at:
+                  updated_at:
+                  name: Vanuatu
+                - id: TL
+                  created_at:
+                  updated_at:
+                  name: Timor-Leste
+                - id: HR
+                  created_at:
+                  updated_at:
+                  name: Croatia
+                - id: SR
+                  created_at:
+                  updated_at:
+                  name: Suriname
+                - id: MU
+                  created_at:
+                  updated_at:
+                  name: Mauritius
+                - id: CZ
+                  created_at:
+                  updated_at:
+                  name: Czechia
+                - id: PM
+                  created_at:
+                  updated_at:
+                  name: Saint Pierre and Miquelon
+                - id: LS
+                  created_at:
+                  updated_at:
+                  name: Lesotho
+                - id: WS
+                  created_at:
+                  updated_at:
+                  name: Samoa
+                - id: KM
+                  created_at:
+                  updated_at:
+                  name: Comoros
+                - id: IT
+                  created_at:
+                  updated_at:
+                  name: Italy
+                - id: BI
+                  created_at:
+                  updated_at:
+                  name: Burundi
+                - id: WF
+                  created_at:
+                  updated_at:
+                  name: Wallis and Futuna
+                - id: GN
+                  created_at:
+                  updated_at:
+                  name: Guinea
+                - id: SG
+                  created_at:
+                  updated_at:
+                  name: Singapore
+                - id: CO
+                  created_at:
+                  updated_at:
+                  name: Colombia
+                - id: CN
+                  created_at:
+                  updated_at:
+                  name: China
+                - id: AW
+                  created_at:
+                  updated_at:
+                  name: Aruba
+                - id: MA
+                  created_at:
+                  updated_at:
+                  name: Morocco
+                - id: FI
+                  created_at:
+                  updated_at:
+                  name: Finland
+                - id: VA
+                  created_at:
+                  updated_at:
+                  name: Holy See (Vatican City State)
+                - id: ZW
+                  created_at:
+                  updated_at:
+                  name: Zimbabwe
+                - id: KY
+                  created_at:
+                  updated_at:
+                  name: Cayman Islands
+                - id: BH
+                  created_at:
+                  updated_at:
+                  name: Bahrain
+                - id: PY
+                  created_at:
+                  updated_at:
+                  name: Paraguay
+                - id: EC
+                  created_at:
+                  updated_at:
+                  name: Ecuador
+                - id: LR
+                  created_at:
+                  updated_at:
+                  name: Liberia
+                - id: RU
+                  created_at:
+                  updated_at:
+                  name: Russian Federation
+                - id: PL
+                  created_at:
+                  updated_at:
+                  name: Poland
+                - id: OM
+                  created_at:
+                  updated_at:
+                  name: Oman
+                - id: MT
+                  created_at:
+                  updated_at:
+                  name: Malta
+                - id: SS
+                  created_at:
+                  updated_at:
+                  name: South Sudan
+                - id: DE
+                  created_at:
+                  updated_at:
+                  name: Germany
+                - id: TM
+                  created_at:
+                  updated_at:
+                  name: Turkmenistan
+                - id: SJ
+                  created_at:
+                  updated_at:
+                  name: Svalbard and Jan Mayen
+                - id: MM
+                  created_at:
+                  updated_at:
+                  name: Myanmar
+                - id: TT
+                  created_at:
+                  updated_at:
+                  name: Trinidad and Tobago
+                - id: IL
+                  created_at:
+                  updated_at:
+                  name: Israel
+                - id: BD
+                  created_at:
+                  updated_at:
+                  name: Bangladesh
+                - id: NR
+                  created_at:
+                  updated_at:
+                  name: Nauru
+                - id: LK
+                  created_at:
+                  updated_at:
+                  name: Sri Lanka
+                - id: UG
+                  created_at:
+                  updated_at:
+                  name: Uganda
+                - id: NG
+                  created_at:
+                  updated_at:
+                  name: Nigeria
+                - id: BQ
+                  created_at:
+                  updated_at:
+                  name: Bonaire, Sint Eustatius and Saba
+                - id: MX
+                  created_at:
+                  updated_at:
+                  name: Mexico
+                - id: CW
+                  created_at:
+                  updated_at:
+                  name: Curaçao
+                - id: SI
+                  created_at:
+                  updated_at:
+                  name: Slovenia
+                - id: MN
+                  created_at:
+                  updated_at:
+                  name: Mongolia
+                - id: CA
+                  created_at:
+                  updated_at:
+                  name: Canada
+                - id: AX
+                  created_at:
+                  updated_at:
+                  name: Åland Islands
+                - id: VN
+                  created_at:
+                  updated_at:
+                  name: Vietnam
+                - id: TW
+                  created_at:
+                  updated_at:
+                  name: Taiwan
+                - id: JP
+                  created_at:
+                  updated_at:
+                  name: Japan
+                - id: IO
+                  created_at:
+                  updated_at:
+                  name: British Indian Ocean Territory
+                - id: RO
+                  created_at:
+                  updated_at:
+                  name: Romania
+                - id: BG
+                  created_at:
+                  updated_at:
+                  name: Bulgaria
+                - id: GU
+                  created_at:
+                  updated_at:
+                  name: Guam
+                - id: BR
+                  created_at:
+                  updated_at:
+                  name: Brazil
+                - id: AM
+                  created_at:
+                  updated_at:
+                  name: Armenia
+                - id: ZM
+                  created_at:
+                  updated_at:
+                  name: Zambia
+                - id: DJ
+                  created_at:
+                  updated_at:
+                  name: Djibouti
+                - id: JE
+                  created_at:
+                  updated_at:
+                  name: Jersey
+                - id: AT
+                  created_at:
+                  updated_at:
+                  name: Austria
+                - id: CM
+                  created_at:
+                  updated_at:
+                  name: Cameroon
+                - id: SE
+                  created_at:
+                  updated_at:
+                  name: Sweden
+                - id: FJ
+                  created_at:
+                  updated_at:
+                  name: Fiji
+                - id: KZ
+                  created_at:
+                  updated_at:
+                  name: Kazakhstan
+                - id: GL
+                  created_at:
+                  updated_at:
+                  name: Greenland
+                - id: GY
+                  created_at:
+                  updated_at:
+                  name: Guyana
+                - id: CX
+                  created_at:
+                  updated_at:
+                  name: Christmas Island
+                - id: MW
+                  created_at:
+                  updated_at:
+                  name: Malawi
+                - id: TN
+                  created_at:
+                  updated_at:
+                  name: Tunisia
+                - id: ZA
+                  created_at:
+                  updated_at:
+                  name: South Africa
+                - id: TO
+                  created_at:
+                  updated_at:
+                  name: Tonga
+                - id: CY
+                  created_at:
+                  updated_at:
+                  name: Cyprus
+                - id: MV
+                  created_at:
+                  updated_at:
+                  name: Maldives
+                - id: PN
+                  created_at:
+                  updated_at:
+                  name: Pitcairn
+                - id: RW
+                  created_at:
+                  updated_at:
+                  name: Rwanda
+                - id: NI
+                  created_at:
+                  updated_at:
+                  name: Nicaragua
+                - id: KN
+                  created_at:
+                  updated_at:
+                  name: Saint Kitts and Nevis
+                - id: BJ
+                  created_at:
+                  updated_at:
+                  name: Benin
+                - id: ET
+                  created_at:
+                  updated_at:
+                  name: Ethiopia
+                - id: GM
+                  created_at:
+                  updated_at:
+                  name: Gambia
+                - id: TZ
+                  created_at:
+                  updated_at:
+                  name: Tanzania
+                - id: VC
+                  created_at:
+                  updated_at:
+                  name: Saint Vincent and the Grenadines
+                - id: FK
+                  created_at:
+                  updated_at:
+                  name: Falkland Islands (Malvinas)
+                - id: SD
+                  created_at:
+                  updated_at:
+                  name: Sudan
+                - id: MC
+                  created_at:
+                  updated_at:
+                  name: Monaco
+                - id: AU
+                  created_at:
+                  updated_at:
+                  name: Australia
+                - id: CL
+                  created_at:
+                  updated_at:
+                  name: Chile
+                - id: DK
+                  created_at:
+                  updated_at:
+                  name: Denmark
+                - id: FR
+                  created_at:
+                  updated_at:
+                  name: France
+                - id: TC
+                  created_at:
+                  updated_at:
+                  name: Turks and Caicos Islands
+                - id: CU
+                  created_at:
+                  updated_at:
+                  name: Cuba
+                - id: AL
+                  created_at:
+                  updated_at:
+                  name: Albania
+                - id: MZ
+                  created_at:
+                  updated_at:
+                  name: Mozambique
+                - id: BS
+                  created_at:
+                  updated_at:
+                  name: Bahamas
+                - id: NE
+                  created_at:
+                  updated_at:
+                  name: Niger
+                - id: GT
+                  created_at:
+                  updated_at:
+                  name: Guatemala
+                - id: LI
+                  created_at:
+                  updated_at:
+                  name: Liechtenstein
+                - id: NP
+                  created_at:
+                  updated_at:
+                  name: Nepal
+                - id: BF
+                  created_at:
+                  updated_at:
+                  name: Burkina Faso
+                - id: PW
+                  created_at:
+                  updated_at:
+                  name: Palau
+                - id: KW
+                  created_at:
+                  updated_at:
+                  name: Kuwait
+                - id: IN
+                  created_at:
+                  updated_at:
+                  name: India
+                - id: GA
+                  created_at:
+                  updated_at:
+                  name: Gabon
+                - id: TV
+                  created_at:
+                  updated_at:
+                  name: Tuvalu
+                - id: MO
+                  created_at:
+                  updated_at:
+                  name: Macao
+                - id: SH
+                  created_at:
+                  updated_at:
+                  name: Saint Helena, Ascension and Tristan da Cunha
+                - id: MD
+                  created_at:
+                  updated_at:
+                  name: Moldova
+                - id: CK
+                  created_at:
+                  updated_at:
+                  name: Cook Islands
+                - id: AR
+                  created_at:
+                  updated_at:
+                  name: Argentina
+                - id: SC
+                  created_at:
+                  updated_at:
+                  name: Seychelles
+                - id: IE
+                  created_at:
+                  updated_at:
+                  name: Ireland
+                - id: ES
+                  created_at:
+                  updated_at:
+                  name: Spain
+                - id: LB
+                  created_at:
+                  updated_at:
+                  name: Lebanon
+                - id: BM
+                  created_at:
+                  updated_at:
+                  name: Bermuda
+                - id: RE
+                  created_at:
+                  updated_at:
+                  name: Réunion
+                - id: KI
+                  created_at:
+                  updated_at:
+                  name: Kiribati
+                - id: AG
+                  created_at:
+                  updated_at:
+                  name: Antigua and Barbuda
+                - id: MQ
+                  created_at:
+                  updated_at:
+                  name: Martinique
+                - id: SV
+                  created_at:
+                  updated_at:
+                  name: El Salvador
+                - id: JO
+                  created_at:
+                  updated_at:
+                  name: Jordan
+                - id: TH
+                  created_at:
+                  updated_at:
+                  name: Thailand
+                - id: SO
+                  created_at:
+                  updated_at:
+                  name: Somalia
+                - id: MH
+                  created_at:
+                  updated_at:
+                  name: Marshall Islands
+                - id: CG
+                  created_at:
+                  updated_at:
+                  name: Congo
+                - id: KP
+                  created_at:
+                  updated_at:
+                  name: Korea, Democratic People's Republic of
+                - id: GF
+                  created_at:
+                  updated_at:
+                  name: French Guiana
+                - id: BA
+                  created_at:
+                  updated_at:
+                  name: Bosnia and Herzegovina
+                - id: YT
+                  created_at:
+                  updated_at:
+                  name: Mayotte
+                - id: GS
+                  created_at:
+                  updated_at:
+                  name: South Georgia and the South Sandwich Islands
+                - id: KE
+                  created_at:
+                  updated_at:
+                  name: Kenya
+                - id: PE
+                  created_at:
+                  updated_at:
+                  name: Peru
+                - id: BT
+                  created_at:
+                  updated_at:
+                  name: Bhutan
+                - id: SZ
+                  created_at:
+                  updated_at:
+                  name: Eswatini
+                - id: CR
+                  created_at:
+                  updated_at:
+                  name: Costa Rica
+                - id: TD
+                  created_at:
+                  updated_at:
+                  name: Chad
+                - id: DM
+                  created_at:
+                  updated_at:
+                  name: Dominica
+                - id: NC
+                  created_at:
+                  updated_at:
+                  name: New Caledonia
+                - id: GR
+                  created_at:
+                  updated_at:
+                  name: Greece
+                - id: GG
+                  created_at:
+                  updated_at:
+                  name: Guernsey
+                - id: HN
+                  created_at:
+                  updated_at:
+                  name: Honduras
+                - id: VI
+                  created_at:
+                  updated_at:
+                  name: Virgin Islands, U.S.
+                - id: CF
+                  created_at:
+                  updated_at:
+                  name: Central African Republic
+                - id: SN
+                  created_at:
+                  updated_at:
+                  name: Senegal
+                - id: AF
+                  created_at:
+                  updated_at:
+                  name: Afghanistan
+                - id: MP
+                  created_at:
+                  updated_at:
+                  name: Northern Mariana Islands
+                - id: PH
+                  created_at:
+                  updated_at:
+                  name: Philippines
+                - id: BY
+                  created_at:
+                  updated_at:
+                  name: Belarus
+                - id: LV
+                  created_at:
+                  updated_at:
+                  name: Latvia
+                - id: 'NO'
+                  created_at:
+                  updated_at:
+                  name: Norway
+                - id: EG
+                  created_at:
+                  updated_at:
+                  name: Egypt
+                - id: KH
+                  created_at:
+                  updated_at:
+                  name: Cambodia
+                - id: IQ
+                  created_at:
+                  updated_at:
+                  name: Iraq
+                - id: LC
+                  created_at:
+                  updated_at:
+                  name: Saint Lucia
+                - id: NZ
+                  created_at:
+                  updated_at:
+                  name: New Zealand
+                - id: BL
+                  created_at:
+                  updated_at:
+                  name: Saint Barthélemy
+                - id: UZ
+                  created_at:
+                  updated_at:
+                  name: Uzbekistan
+                - id: ID
+                  created_at:
+                  updated_at:
+                  name: Indonesia
+                - id: ER
+                  created_at:
+                  updated_at:
+                  name: Eritrea
+                - id: VE
+                  created_at:
+                  updated_at:
+                  name: Venezuela
+                - id: FM
+                  created_at:
+                  updated_at:
+                  name: Micronesia, Federated States of
+                - id: SB
+                  created_at:
+                  updated_at:
+                  name: Solomon Islands
+                - id: ME
+                  created_at:
+                  updated_at:
+                  name: Montenegro
+                - id: AS
+                  created_at:
+                  updated_at:
+                  name: American Samoa
   "/api/countries/{id}":
     parameters:
     - name: id
@@ -81,6 +1081,14 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                country:
+                  id: US
+                  created_at:
+                  updated_at:
+                  name: United States
   "/api/day_habits":
     get:
       summary: list day_habits
@@ -275,8 +1283,8 @@ paths:
               example:
                 symptom:
                   id: 1
-                  created_at: '2023-07-30T14:42:56.245Z'
-                  updated_at: '2023-07-30T14:42:56.245Z'
+                  created_at: '2023-07-30T15:01:28.579Z'
+                  updated_at: '2023-07-30T15:01:28.579Z'
                   type: symptom
                   color_id:
                   users_count: 0

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1133,6 +1133,65 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                ethnicities:
+                - id: latino
+                  created_at:
+                  updated_at:
+                  name: Latino or Hispanic
+                  rank: 1
+                - id: white
+                  created_at:
+                  updated_at:
+                  name: European or White
+                  rank: 2
+                - id: east_asian
+                  created_at:
+                  updated_at:
+                  name: East Asian
+                  rank: 3
+                - id: south_asian
+                  created_at:
+                  updated_at:
+                  name: South Asian
+                  rank: 4
+                - id: black
+                  created_at:
+                  updated_at:
+                  name: African American or Black
+                  rank: 5
+                - id: oceanian
+                  created_at:
+                  updated_at:
+                  name: Pacific Islander or Oceanian
+                  rank: 6
+                - id: middle_eastern
+                  created_at:
+                  updated_at:
+                  name: Middle Eastern or North African
+                  rank: 7
+                - id: native_american
+                  created_at:
+                  updated_at:
+                  name: Native American or Alaska Native
+                  rank: 8
+                - id: african
+                  created_at:
+                  updated_at:
+                  name: Sub-Saharan African
+                  rank: 9
+                - id: other
+                  created_at:
+                  updated_at:
+                  name: Other
+                  rank: 10
+                - id: not_sure
+                  created_at:
+                  updated_at:
+                  name: I'm not sure
+                  rank: 11
   "/api/ethnicities/{id}":
     parameters:
     - name: id
@@ -1146,6 +1205,15 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              example:
+                ethnicity:
+                  id: latino
+                  created_at:
+                  updated_at:
+                  name: Latino or Hispanic
+                  rank: 1
   "/api/passwords":
     post:
       summary: create password
@@ -1283,8 +1351,8 @@ paths:
               example:
                 symptom:
                   id: 1
-                  created_at: '2023-07-30T15:01:28.579Z'
-                  updated_at: '2023-07-30T15:01:28.579Z'
+                  created_at: '2023-07-30T15:13:37.870Z'
+                  updated_at: '2023-07-30T15:13:37.870Z'
                   type: symptom
                   color_id:
                   users_count: 0

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -272,35 +272,15 @@ paths:
           description: successful
           content:
             application/json:
-              schema:
-                type: object
-                properties:
-                  symptom:
-                    type: object
-                    properties:
-                      id:
-                        type: integer
-                        required: true
-                      updated_at:
-                        type: string
-                        required: true
-                      created_at:
-                        type: string
-                        required: true
-                      type:
-                        type: string
-                        required: true
-                      color_id:
-                        type: integer
-                        nullable: true
-                      users_count:
-                        type: integer
-                        required: true
-                      name:
-                        type: string
-                        required: true
-                required:
-                - symptom
+              example:
+                symptom:
+                  id: 1
+                  created_at: '2023-07-30T14:42:56.245Z'
+                  updated_at: '2023-07-30T14:42:56.245Z'
+                  type: symptom
+                  color_id:
+                  users_count: 0
+                  name: Symptom1
   "/api/tags":
     get:
       summary: list tags

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1351,8 +1351,8 @@ paths:
               example:
                 password:
                   id: '123'
-                  created_at: '2023-07-29T21:16:17.837Z'
-                  updated_at: '2023-07-29T21:16:17.847Z'
+                  created_at: '2023-07-29T22:44:52.661Z'
+                  updated_at: '2023-07-29T22:44:52.671Z'
                   email: user18@example.com
                   reset_password_token: '123'
                   current_password:
@@ -1559,8 +1559,8 @@ paths:
               example:
                 symptom:
                   id: 1
-                  created_at: '2023-07-29T19:21:51.631Z'
-                  updated_at: '2023-07-29T19:21:51.631Z'
+                  created_at: '2023-07-29T22:44:53.365Z'
+                  updated_at: '2023-07-29T22:44:53.365Z'
                   type: symptom
                   color_id:
                   users_count: 0
@@ -1737,16 +1737,16 @@ paths:
               example:
                 user:
                   id: 44
-                  created_at: '2023-07-29T21:16:19.276Z'
-                  updated_at: '2023-07-29T21:16:19.288Z'
+                  created_at: '2023-07-29T22:44:53.954Z'
+                  updated_at: '2023-07-29T22:44:53.966Z'
                   email: user44@example.com
                   intercom_hash: 1b72b549ef1f8a6f2badcc28b160b8e42d547ea019a2e01a5e0cdec805cb1038
-                  topic_following_id: 64c581a30fabf06c40d60ded
+                  topic_following_id: 64c596650fabf076afb69632
                   profile_id: 44
                 profiles:
                 - id: 44
-                  created_at: '2023-07-29T21:16:19.280Z'
-                  updated_at: '2023-07-29T21:16:19.280Z'
+                  created_at: '2023-07-29T22:44:53.958Z'
+                  updated_at: '2023-07-29T22:44:53.958Z'
                   screen_name:
                   birth_date:
                   country_id:
@@ -1759,7 +1759,7 @@ paths:
                   pressure_units: mb
                   temperature_units: f
                   beta_tester: false
-                  notify_token: feb69ef67925d11393521bc5db6a2be2
+                  notify_token: 436550160eed6aa631b6947f8c84ed89
                   notify: true
                   checkin_reminder: true
                   checkin_reminder_at:
@@ -1778,16 +1778,16 @@ paths:
               example:
                 user:
                   id: 45
-                  created_at: '2023-07-29T21:16:19.345Z'
-                  updated_at: '2023-07-29T21:16:19.379Z'
+                  created_at: '2023-07-29T22:44:54.029Z'
+                  updated_at: '2023-07-29T22:44:54.066Z'
                   email: updatedemail@example.com
                   intercom_hash: 7ab8b7681a8d33388b86b73953e0df9e6305458416f3a5293ca0ca37335a3328
-                  topic_following_id: 64c581a30fabf06c40d60dee
+                  topic_following_id: 64c596660fabf076afb69633
                   profile_id: 45
                 profiles:
                 - id: 45
-                  created_at: '2023-07-29T21:16:19.349Z'
-                  updated_at: '2023-07-29T21:16:19.349Z'
+                  created_at: '2023-07-29T22:44:54.032Z'
+                  updated_at: '2023-07-29T22:44:54.032Z'
                   screen_name:
                   birth_date:
                   country_id:
@@ -1800,7 +1800,7 @@ paths:
                   pressure_units: mb
                   temperature_units: f
                   beta_tester: false
-                  notify_token: 62ff91cef790c63fd310e939f1dec155
+                  notify_token: 743ad1a9a5340b98725f5f3e343c9bec
                   notify: true
                   checkin_reminder: true
                   checkin_reminder_at:
@@ -1821,6 +1821,12 @@ paths:
                       type: string
               required:
               - user
+            examples:
+              request_example_1:
+                summary: A request example
+                value:
+                  user:
+                    email: updatedemail@example.com
     put:
       summary: update user
       responses:

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -1351,8 +1351,8 @@ paths:
               example:
                 password:
                   id: '123'
-                  created_at: '2023-07-29T19:26:08.597Z'
-                  updated_at: '2023-07-29T19:26:08.608Z'
+                  created_at: '2023-07-29T21:16:17.837Z'
+                  updated_at: '2023-07-29T21:16:17.847Z'
                   email: user18@example.com
                   reset_password_token: '123'
                   current_password:
@@ -1735,18 +1735,92 @@ paths:
           content:
             application/json:
               example:
-                errors:
-                - Resource Not Found
+                user:
+                  id: 44
+                  created_at: '2023-07-29T21:16:19.276Z'
+                  updated_at: '2023-07-29T21:16:19.288Z'
+                  email: user44@example.com
+                  intercom_hash: 1b72b549ef1f8a6f2badcc28b160b8e42d547ea019a2e01a5e0cdec805cb1038
+                  topic_following_id: 64c581a30fabf06c40d60ded
+                  profile_id: 44
+                profiles:
+                - id: 44
+                  created_at: '2023-07-29T21:16:19.280Z'
+                  updated_at: '2023-07-29T21:16:19.280Z'
+                  screen_name:
+                  birth_date:
+                  country_id:
+                  sex_id:
+                  onboarding_step_id: onboarding-personal
+                  ethnicity_ids: []
+                  day_habit_id:
+                  education_level_id:
+                  day_walking_hours:
+                  pressure_units: mb
+                  temperature_units: f
+                  beta_tester: false
+                  notify_token: feb69ef67925d11393521bc5db6a2be2
+                  notify: true
+                  checkin_reminder: true
+                  checkin_reminder_at:
+                    hours: 20
+                    minutes: 0
+                  time_zone_name: America/New_York
+                  notify_top_posts: true
     patch:
       summary: update user
+      parameters: []
       responses:
         '200':
           description: successful
           content:
             application/json:
               example:
-                errors:
-                - Resource Not Found
+                user:
+                  id: 45
+                  created_at: '2023-07-29T21:16:19.345Z'
+                  updated_at: '2023-07-29T21:16:19.379Z'
+                  email: updatedemail@example.com
+                  intercom_hash: 7ab8b7681a8d33388b86b73953e0df9e6305458416f3a5293ca0ca37335a3328
+                  topic_following_id: 64c581a30fabf06c40d60dee
+                  profile_id: 45
+                profiles:
+                - id: 45
+                  created_at: '2023-07-29T21:16:19.349Z'
+                  updated_at: '2023-07-29T21:16:19.349Z'
+                  screen_name:
+                  birth_date:
+                  country_id:
+                  sex_id:
+                  onboarding_step_id: onboarding-personal
+                  ethnicity_ids: []
+                  day_habit_id:
+                  education_level_id:
+                  day_walking_hours:
+                  pressure_units: mb
+                  temperature_units: f
+                  beta_tester: false
+                  notify_token: 62ff91cef790c63fd310e939f1dec155
+                  notify: true
+                  checkin_reminder: true
+                  checkin_reminder_at:
+                    hours: 20
+                    minutes: 0
+                  time_zone_name: America/New_York
+                  notify_top_posts: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+              required:
+              - user
     put:
       summary: update user
       responses:
@@ -1756,7 +1830,7 @@ paths:
             application/json:
               example:
                 errors:
-                - Resource Not Found
+                - 'Required parameter missing: user'
   "/api/weathers":
     get:
       summary: list weathers

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -4,6 +4,7 @@ info:
   title: API V1
   version: v1
 paths:
+<<<<<<< HEAD
   "/api/countries":
     get:
       summary: list countries
@@ -1030,6 +1031,262 @@ paths:
                   created_at:
                   updated_at:
                   name: United States
+||||||| parent of 64d8356f (Add swagger request specs for controllers and regenerate swagger file)
+=======
+  "/api/checkins":
+    get:
+      summary: list checkins
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create checkin
+      responses:
+        '200':
+          description: successful
+  "/api/checkins/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show checkin
+      responses:
+        '200':
+          description: successful
+    patch:
+      summary: update checkin
+      responses:
+        '200':
+          description: successful
+    put:
+      summary: update checkin
+      responses:
+        '200':
+          description: successful
+  "/api/conditions":
+    get:
+      summary: list conditions
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create condition
+      responses:
+        '200':
+          description: successful
+  "/api/conditions/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show condition
+      responses:
+        '200':
+          description: successful
+  "/api/countries":
+    get:
+      summary: list countries
+      responses:
+        '200':
+          description: successful
+  "/api/countries/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show country
+      responses:
+        '200':
+          description: successful
+  "/api/day_habits":
+    get:
+      summary: list day_habits
+      responses:
+        '200':
+          description: successful
+  "/api/day_habits/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show day_habit
+      responses:
+        '200':
+          description: successful
+  "/api/education_levels":
+    get:
+      summary: list education_levels
+      responses:
+        '200':
+          description: successful
+  "/api/education_levels/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show education_level
+      responses:
+        '200':
+          description: successful
+  "/api/ethnicities":
+    get:
+      summary: list ethnicities
+      responses:
+        '200':
+          description: successful
+  "/api/ethnicities/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show ethnicity
+      responses:
+        '200':
+          description: successful
+  "/api/passwords":
+    post:
+      summary: create password
+      responses:
+        '200':
+          description: successful
+  "/api/passwords/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show password
+      responses:
+        '200':
+          description: successful
+    patch:
+      summary: update password
+      responses:
+        '200':
+          description: successful
+    put:
+      summary: update password
+      responses:
+        '200':
+          description: successful
+  "/api/posts":
+    get:
+      summary: list posts
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create post
+      responses:
+        '200':
+          description: successful
+  "/api/posts/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show post
+      responses:
+        '200':
+          description: successful
+  "/api/profiles":
+    get:
+      summary: list profiles
+      responses:
+        '200':
+          description: successful
+  "/api/profiles/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show profile
+      responses:
+        '200':
+          description: successful
+    patch:
+      summary: update profile
+      responses:
+        '200':
+          description: successful
+    put:
+      summary: update profile
+      responses:
+        '200':
+          description: successful
+  "/api/registrations/destroy":
+    put:
+      summary: delete registration
+      responses:
+        '200':
+          description: successful
+  "/api/registrations":
+    post:
+      summary: create registration
+      responses:
+        '200':
+          description: successful
+  "/api/searches":
+    get:
+      summary: show search
+      responses:
+        '200':
+          description: successful
+  "/api/sexes":
+    get:
+      summary: list sexes
+      responses:
+        '200':
+          description: successful
+  "/api/sexes/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show sex
+      responses:
+        '200':
+          description: successful
+>>>>>>> 64d8356f (Add swagger request specs for controllers and regenerate swagger file)
   "/api/symptoms/{id}":
     get:
       summary: show symptom
@@ -1083,6 +1340,112 @@ paths:
                         required: true
                 required:
                 - symptom
+  "/api/tags":
+    get:
+      summary: list tags
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create tag
+      responses:
+        '200':
+          description: successful
+  "/api/tags/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show tag
+      responses:
+        '200':
+          description: successful
+  "/api/trackings":
+    get:
+      summary: list trackings
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create tracking
+      responses:
+        '200':
+          description: successful
+  "/api/trackings/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show tracking
+      responses:
+        '200':
+          description: successful
+    delete:
+      summary: delete tracking
+      responses:
+        '200':
+          description: successful
+  "/api/treatments":
+    get:
+      summary: list treatments
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create treatment
+      responses:
+        '200':
+          description: successful
+  "/api/treatments/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show treatment
+      responses:
+        '200':
+          description: successful
+  "/api/users/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show user
+      responses:
+        '200':
+          description: successful
+    patch:
+      summary: update user
+      responses:
+        '200':
+          description: successful
+    put:
+      summary: update user
+      responses:
+        '200':
+          description: successful
+  "/api/weathers":
+    get:
+      summary: list weathers
+      responses:
+        '200':
+          description: successful
 servers:
 - url: http://localhost:3000
   description: local documentation

--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -10,21 +10,11 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: page'
     post:
       summary: create checkin
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: checkin'
   "/api/checkins/{id}":
     parameters:
     - name: id
@@ -38,51 +28,27 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
     patch:
       summary: update checkin
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
     put:
       summary: update checkin
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
   "/api/conditions":
     get:
       summary: list conditions
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                conditions: []
     post:
       summary: create condition
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: condition'
   "/api/conditions/{id}":
     parameters:
     - name: id
@@ -96,1016 +62,12 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
   "/api/countries":
     get:
       summary: list countries
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-              - id: TJ
-                created_at:
-                updated_at:
-                name: Tajikistan
-              - id: JM
-                created_at:
-                updated_at:
-                name: Jamaica
-              - id: HT
-                created_at:
-                updated_at:
-                name: Haiti
-              - id: ST
-                created_at:
-                updated_at:
-                name: Sao Tome and Principe
-              - id: MS
-                created_at:
-                updated_at:
-                name: Montserrat
-              - id: AE
-                created_at:
-                updated_at:
-                name: United Arab Emirates
-              - id: PK
-                created_at:
-                updated_at:
-                name: Pakistan
-              - id: NL
-                created_at:
-                updated_at:
-                name: Netherlands
-              - id: LU
-                created_at:
-                updated_at:
-                name: Luxembourg
-              - id: BZ
-                created_at:
-                updated_at:
-                name: Belize
-              - id: IR
-                created_at:
-                updated_at:
-                name: Iran, Islamic Republic of
-              - id: BO
-                created_at:
-                updated_at:
-                name: Bolivia
-              - id: UY
-                created_at:
-                updated_at:
-                name: Uruguay
-              - id: GH
-                created_at:
-                updated_at:
-                name: Ghana
-              - id: SA
-                created_at:
-                updated_at:
-                name: Saudi Arabia
-              - id: CI
-                created_at:
-                updated_at:
-                name: Côte d'Ivoire
-              - id: MF
-                created_at:
-                updated_at:
-                name: Saint Martin (French part)
-              - id: TF
-                created_at:
-                updated_at:
-                name: French Southern Territories
-              - id: AI
-                created_at:
-                updated_at:
-                name: Anguilla
-              - id: QA
-                created_at:
-                updated_at:
-                name: Qatar
-              - id: SX
-                created_at:
-                updated_at:
-                name: Sint Maarten (Dutch part)
-              - id: LY
-                created_at:
-                updated_at:
-                name: Libya
-              - id: BV
-                created_at:
-                updated_at:
-                name: Bouvet Island
-              - id: PG
-                created_at:
-                updated_at:
-                name: Papua New Guinea
-              - id: KG
-                created_at:
-                updated_at:
-                name: Kyrgyzstan
-              - id: GQ
-                created_at:
-                updated_at:
-                name: Equatorial Guinea
-              - id: EH
-                created_at:
-                updated_at:
-                name: Western Sahara
-              - id: NU
-                created_at:
-                updated_at:
-                name: Niue
-              - id: PR
-                created_at:
-                updated_at:
-                name: Puerto Rico
-              - id: GD
-                created_at:
-                updated_at:
-                name: Grenada
-              - id: KR
-                created_at:
-                updated_at:
-                name: Korea, Republic of
-              - id: HM
-                created_at:
-                updated_at:
-                name: Heard Island and McDonald Islands
-              - id: SM
-                created_at:
-                updated_at:
-                name: San Marino
-              - id: SL
-                created_at:
-                updated_at:
-                name: Sierra Leone
-              - id: CD
-                created_at:
-                updated_at:
-                name: Congo, The Democratic Republic of the
-              - id: MK
-                created_at:
-                updated_at:
-                name: North Macedonia
-              - id: TR
-                created_at:
-                updated_at:
-                name: Turkey
-              - id: DZ
-                created_at:
-                updated_at:
-                name: Algeria
-              - id: GE
-                created_at:
-                updated_at:
-                name: Georgia
-              - id: PS
-                created_at:
-                updated_at:
-                name: Palestine, State of
-              - id: BB
-                created_at:
-                updated_at:
-                name: Barbados
-              - id: UA
-                created_at:
-                updated_at:
-                name: Ukraine
-              - id: GP
-                created_at:
-                updated_at:
-                name: Guadeloupe
-              - id: PF
-                created_at:
-                updated_at:
-                name: French Polynesia
-              - id: NA
-                created_at:
-                updated_at:
-                name: Namibia
-              - id: BW
-                created_at:
-                updated_at:
-                name: Botswana
-              - id: SY
-                created_at:
-                updated_at:
-                name: Syrian Arab Republic
-              - id: TG
-                created_at:
-                updated_at:
-                name: Togo
-              - id: DO
-                created_at:
-                updated_at:
-                name: Dominican Republic
-              - id: AQ
-                created_at:
-                updated_at:
-                name: Antarctica
-              - id: CH
-                created_at:
-                updated_at:
-                name: Switzerland
-              - id: MG
-                created_at:
-                updated_at:
-                name: Madagascar
-              - id: FO
-                created_at:
-                updated_at:
-                name: Faroe Islands
-              - id: VG
-                created_at:
-                updated_at:
-                name: Virgin Islands, British
-              - id: GI
-                created_at:
-                updated_at:
-                name: Gibraltar
-              - id: BN
-                created_at:
-                updated_at:
-                name: Brunei Darussalam
-              - id: LA
-                created_at:
-                updated_at:
-                name: Lao People's Democratic Republic
-              - id: IS
-                created_at:
-                updated_at:
-                name: Iceland
-              - id: EE
-                created_at:
-                updated_at:
-                name: Estonia
-              - id: UM
-                created_at:
-                updated_at:
-                name: United States Minor Outlying Islands
-              - id: LT
-                created_at:
-                updated_at:
-                name: Lithuania
-              - id: RS
-                created_at:
-                updated_at:
-                name: Serbia
-              - id: MR
-                created_at:
-                updated_at:
-                name: Mauritania
-              - id: AD
-                created_at:
-                updated_at:
-                name: Andorra
-              - id: HU
-                created_at:
-                updated_at:
-                name: Hungary
-              - id: TK
-                created_at:
-                updated_at:
-                name: Tokelau
-              - id: MY
-                created_at:
-                updated_at:
-                name: Malaysia
-              - id: AO
-                created_at:
-                updated_at:
-                name: Angola
-              - id: CV
-                created_at:
-                updated_at:
-                name: Cabo Verde
-              - id: NF
-                created_at:
-                updated_at:
-                name: Norfolk Island
-              - id: PA
-                created_at:
-                updated_at:
-                name: Panama
-              - id: GW
-                created_at:
-                updated_at:
-                name: Guinea-Bissau
-              - id: BE
-                created_at:
-                updated_at:
-                name: Belgium
-              - id: PT
-                created_at:
-                updated_at:
-                name: Portugal
-              - id: GB
-                created_at:
-                updated_at:
-                name: United Kingdom
-              - id: IM
-                created_at:
-                updated_at:
-                name: Isle of Man
-              - id: US
-                created_at:
-                updated_at:
-                name: United States
-              - id: YE
-                created_at:
-                updated_at:
-                name: Yemen
-              - id: HK
-                created_at:
-                updated_at:
-                name: Hong Kong
-              - id: AZ
-                created_at:
-                updated_at:
-                name: Azerbaijan
-              - id: CC
-                created_at:
-                updated_at:
-                name: Cocos (Keeling) Islands
-              - id: ML
-                created_at:
-                updated_at:
-                name: Mali
-              - id: SK
-                created_at:
-                updated_at:
-                name: Slovakia
-              - id: VU
-                created_at:
-                updated_at:
-                name: Vanuatu
-              - id: TL
-                created_at:
-                updated_at:
-                name: Timor-Leste
-              - id: HR
-                created_at:
-                updated_at:
-                name: Croatia
-              - id: SR
-                created_at:
-                updated_at:
-                name: Suriname
-              - id: MU
-                created_at:
-                updated_at:
-                name: Mauritius
-              - id: CZ
-                created_at:
-                updated_at:
-                name: Czechia
-              - id: PM
-                created_at:
-                updated_at:
-                name: Saint Pierre and Miquelon
-              - id: LS
-                created_at:
-                updated_at:
-                name: Lesotho
-              - id: WS
-                created_at:
-                updated_at:
-                name: Samoa
-              - id: KM
-                created_at:
-                updated_at:
-                name: Comoros
-              - id: IT
-                created_at:
-                updated_at:
-                name: Italy
-              - id: BI
-                created_at:
-                updated_at:
-                name: Burundi
-              - id: WF
-                created_at:
-                updated_at:
-                name: Wallis and Futuna
-              - id: GN
-                created_at:
-                updated_at:
-                name: Guinea
-              - id: SG
-                created_at:
-                updated_at:
-                name: Singapore
-              - id: CO
-                created_at:
-                updated_at:
-                name: Colombia
-              - id: CN
-                created_at:
-                updated_at:
-                name: China
-              - id: AW
-                created_at:
-                updated_at:
-                name: Aruba
-              - id: MA
-                created_at:
-                updated_at:
-                name: Morocco
-              - id: FI
-                created_at:
-                updated_at:
-                name: Finland
-              - id: VA
-                created_at:
-                updated_at:
-                name: Holy See (Vatican City State)
-              - id: ZW
-                created_at:
-                updated_at:
-                name: Zimbabwe
-              - id: KY
-                created_at:
-                updated_at:
-                name: Cayman Islands
-              - id: BH
-                created_at:
-                updated_at:
-                name: Bahrain
-              - id: PY
-                created_at:
-                updated_at:
-                name: Paraguay
-              - id: EC
-                created_at:
-                updated_at:
-                name: Ecuador
-              - id: LR
-                created_at:
-                updated_at:
-                name: Liberia
-              - id: RU
-                created_at:
-                updated_at:
-                name: Russian Federation
-              - id: PL
-                created_at:
-                updated_at:
-                name: Poland
-              - id: OM
-                created_at:
-                updated_at:
-                name: Oman
-              - id: MT
-                created_at:
-                updated_at:
-                name: Malta
-              - id: SS
-                created_at:
-                updated_at:
-                name: South Sudan
-              - id: DE
-                created_at:
-                updated_at:
-                name: Germany
-              - id: TM
-                created_at:
-                updated_at:
-                name: Turkmenistan
-              - id: SJ
-                created_at:
-                updated_at:
-                name: Svalbard and Jan Mayen
-              - id: MM
-                created_at:
-                updated_at:
-                name: Myanmar
-              - id: TT
-                created_at:
-                updated_at:
-                name: Trinidad and Tobago
-              - id: IL
-                created_at:
-                updated_at:
-                name: Israel
-              - id: BD
-                created_at:
-                updated_at:
-                name: Bangladesh
-              - id: NR
-                created_at:
-                updated_at:
-                name: Nauru
-              - id: LK
-                created_at:
-                updated_at:
-                name: Sri Lanka
-              - id: UG
-                created_at:
-                updated_at:
-                name: Uganda
-              - id: NG
-                created_at:
-                updated_at:
-                name: Nigeria
-              - id: BQ
-                created_at:
-                updated_at:
-                name: Bonaire, Sint Eustatius and Saba
-              - id: MX
-                created_at:
-                updated_at:
-                name: Mexico
-              - id: CW
-                created_at:
-                updated_at:
-                name: Curaçao
-              - id: SI
-                created_at:
-                updated_at:
-                name: Slovenia
-              - id: MN
-                created_at:
-                updated_at:
-                name: Mongolia
-              - id: CA
-                created_at:
-                updated_at:
-                name: Canada
-              - id: AX
-                created_at:
-                updated_at:
-                name: Åland Islands
-              - id: VN
-                created_at:
-                updated_at:
-                name: Vietnam
-              - id: TW
-                created_at:
-                updated_at:
-                name: Taiwan
-              - id: JP
-                created_at:
-                updated_at:
-                name: Japan
-              - id: IO
-                created_at:
-                updated_at:
-                name: British Indian Ocean Territory
-              - id: RO
-                created_at:
-                updated_at:
-                name: Romania
-              - id: BG
-                created_at:
-                updated_at:
-                name: Bulgaria
-              - id: GU
-                created_at:
-                updated_at:
-                name: Guam
-              - id: BR
-                created_at:
-                updated_at:
-                name: Brazil
-              - id: AM
-                created_at:
-                updated_at:
-                name: Armenia
-              - id: ZM
-                created_at:
-                updated_at:
-                name: Zambia
-              - id: DJ
-                created_at:
-                updated_at:
-                name: Djibouti
-              - id: JE
-                created_at:
-                updated_at:
-                name: Jersey
-              - id: AT
-                created_at:
-                updated_at:
-                name: Austria
-              - id: CM
-                created_at:
-                updated_at:
-                name: Cameroon
-              - id: SE
-                created_at:
-                updated_at:
-                name: Sweden
-              - id: FJ
-                created_at:
-                updated_at:
-                name: Fiji
-              - id: KZ
-                created_at:
-                updated_at:
-                name: Kazakhstan
-              - id: GL
-                created_at:
-                updated_at:
-                name: Greenland
-              - id: GY
-                created_at:
-                updated_at:
-                name: Guyana
-              - id: CX
-                created_at:
-                updated_at:
-                name: Christmas Island
-              - id: MW
-                created_at:
-                updated_at:
-                name: Malawi
-              - id: TN
-                created_at:
-                updated_at:
-                name: Tunisia
-              - id: ZA
-                created_at:
-                updated_at:
-                name: South Africa
-              - id: TO
-                created_at:
-                updated_at:
-                name: Tonga
-              - id: CY
-                created_at:
-                updated_at:
-                name: Cyprus
-              - id: MV
-                created_at:
-                updated_at:
-                name: Maldives
-              - id: PN
-                created_at:
-                updated_at:
-                name: Pitcairn
-              - id: RW
-                created_at:
-                updated_at:
-                name: Rwanda
-              - id: NI
-                created_at:
-                updated_at:
-                name: Nicaragua
-              - id: KN
-                created_at:
-                updated_at:
-                name: Saint Kitts and Nevis
-              - id: BJ
-                created_at:
-                updated_at:
-                name: Benin
-              - id: ET
-                created_at:
-                updated_at:
-                name: Ethiopia
-              - id: GM
-                created_at:
-                updated_at:
-                name: Gambia
-              - id: TZ
-                created_at:
-                updated_at:
-                name: Tanzania
-              - id: VC
-                created_at:
-                updated_at:
-                name: Saint Vincent and the Grenadines
-              - id: FK
-                created_at:
-                updated_at:
-                name: Falkland Islands (Malvinas)
-              - id: SD
-                created_at:
-                updated_at:
-                name: Sudan
-              - id: MC
-                created_at:
-                updated_at:
-                name: Monaco
-              - id: AU
-                created_at:
-                updated_at:
-                name: Australia
-              - id: CL
-                created_at:
-                updated_at:
-                name: Chile
-              - id: DK
-                created_at:
-                updated_at:
-                name: Denmark
-              - id: FR
-                created_at:
-                updated_at:
-                name: France
-              - id: TC
-                created_at:
-                updated_at:
-                name: Turks and Caicos Islands
-              - id: CU
-                created_at:
-                updated_at:
-                name: Cuba
-              - id: AL
-                created_at:
-                updated_at:
-                name: Albania
-              - id: MZ
-                created_at:
-                updated_at:
-                name: Mozambique
-              - id: BS
-                created_at:
-                updated_at:
-                name: Bahamas
-              - id: NE
-                created_at:
-                updated_at:
-                name: Niger
-              - id: GT
-                created_at:
-                updated_at:
-                name: Guatemala
-              - id: LI
-                created_at:
-                updated_at:
-                name: Liechtenstein
-              - id: NP
-                created_at:
-                updated_at:
-                name: Nepal
-              - id: BF
-                created_at:
-                updated_at:
-                name: Burkina Faso
-              - id: PW
-                created_at:
-                updated_at:
-                name: Palau
-              - id: KW
-                created_at:
-                updated_at:
-                name: Kuwait
-              - id: IN
-                created_at:
-                updated_at:
-                name: India
-              - id: GA
-                created_at:
-                updated_at:
-                name: Gabon
-              - id: TV
-                created_at:
-                updated_at:
-                name: Tuvalu
-              - id: MO
-                created_at:
-                updated_at:
-                name: Macao
-              - id: SH
-                created_at:
-                updated_at:
-                name: Saint Helena, Ascension and Tristan da Cunha
-              - id: MD
-                created_at:
-                updated_at:
-                name: Moldova
-              - id: CK
-                created_at:
-                updated_at:
-                name: Cook Islands
-              - id: AR
-                created_at:
-                updated_at:
-                name: Argentina
-              - id: SC
-                created_at:
-                updated_at:
-                name: Seychelles
-              - id: IE
-                created_at:
-                updated_at:
-                name: Ireland
-              - id: ES
-                created_at:
-                updated_at:
-                name: Spain
-              - id: LB
-                created_at:
-                updated_at:
-                name: Lebanon
-              - id: BM
-                created_at:
-                updated_at:
-                name: Bermuda
-              - id: RE
-                created_at:
-                updated_at:
-                name: Réunion
-              - id: KI
-                created_at:
-                updated_at:
-                name: Kiribati
-              - id: AG
-                created_at:
-                updated_at:
-                name: Antigua and Barbuda
-              - id: MQ
-                created_at:
-                updated_at:
-                name: Martinique
-              - id: SV
-                created_at:
-                updated_at:
-                name: El Salvador
-              - id: JO
-                created_at:
-                updated_at:
-                name: Jordan
-              - id: TH
-                created_at:
-                updated_at:
-                name: Thailand
-              - id: SO
-                created_at:
-                updated_at:
-                name: Somalia
-              - id: MH
-                created_at:
-                updated_at:
-                name: Marshall Islands
-              - id: CG
-                created_at:
-                updated_at:
-                name: Congo
-              - id: KP
-                created_at:
-                updated_at:
-                name: Korea, Democratic People's Republic of
-              - id: GF
-                created_at:
-                updated_at:
-                name: French Guiana
-              - id: BA
-                created_at:
-                updated_at:
-                name: Bosnia and Herzegovina
-              - id: YT
-                created_at:
-                updated_at:
-                name: Mayotte
-              - id: GS
-                created_at:
-                updated_at:
-                name: South Georgia and the South Sandwich Islands
-              - id: KE
-                created_at:
-                updated_at:
-                name: Kenya
-              - id: PE
-                created_at:
-                updated_at:
-                name: Peru
-              - id: BT
-                created_at:
-                updated_at:
-                name: Bhutan
-              - id: SZ
-                created_at:
-                updated_at:
-                name: Eswatini
-              - id: CR
-                created_at:
-                updated_at:
-                name: Costa Rica
-              - id: TD
-                created_at:
-                updated_at:
-                name: Chad
-              - id: DM
-                created_at:
-                updated_at:
-                name: Dominica
-              - id: NC
-                created_at:
-                updated_at:
-                name: New Caledonia
-              - id: GR
-                created_at:
-                updated_at:
-                name: Greece
-              - id: GG
-                created_at:
-                updated_at:
-                name: Guernsey
-              - id: HN
-                created_at:
-                updated_at:
-                name: Honduras
-              - id: VI
-                created_at:
-                updated_at:
-                name: Virgin Islands, U.S.
-              - id: CF
-                created_at:
-                updated_at:
-                name: Central African Republic
-              - id: SN
-                created_at:
-                updated_at:
-                name: Senegal
-              - id: AF
-                created_at:
-                updated_at:
-                name: Afghanistan
-              - id: MP
-                created_at:
-                updated_at:
-                name: Northern Mariana Islands
-              - id: PH
-                created_at:
-                updated_at:
-                name: Philippines
-              - id: BY
-                created_at:
-                updated_at:
-                name: Belarus
-              - id: LV
-                created_at:
-                updated_at:
-                name: Latvia
-              - id: 'NO'
-                created_at:
-                updated_at:
-                name: Norway
-              - id: EG
-                created_at:
-                updated_at:
-                name: Egypt
-              - id: KH
-                created_at:
-                updated_at:
-                name: Cambodia
-              - id: IQ
-                created_at:
-                updated_at:
-                name: Iraq
-              - id: LC
-                created_at:
-                updated_at:
-                name: Saint Lucia
-              - id: NZ
-                created_at:
-                updated_at:
-                name: New Zealand
-              - id: BL
-                created_at:
-                updated_at:
-                name: Saint Barthélemy
-              - id: UZ
-                created_at:
-                updated_at:
-                name: Uzbekistan
-              - id: ID
-                created_at:
-                updated_at:
-                name: Indonesia
-              - id: ER
-                created_at:
-                updated_at:
-                name: Eritrea
-              - id: VE
-                created_at:
-                updated_at:
-                name: Venezuela
-              - id: FM
-                created_at:
-                updated_at:
-                name: Micronesia, Federated States of
-              - id: SB
-                created_at:
-                updated_at:
-                name: Solomon Islands
-              - id: ME
-                created_at:
-                updated_at:
-                name: Montenegro
-              - id: AS
-                created_at:
-                updated_at:
-                name: American Samoa
   "/api/countries/{id}":
     parameters:
     - name: id
@@ -1119,55 +81,12 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                country:
-                  id: US
-                  created_at:
-                  updated_at:
-                  name: United States
   "/api/day_habits":
     get:
       summary: list day_habits
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                day_habits:
-                - id: lying_down
-                  created_at:
-                  updated_at:
-                  name: Lying down
-                  rank: 1
-                  description: bedridden
-                - id: sitting_down
-                  created_at:
-                  updated_at:
-                  name: Sitting down or at a computer
-                  rank: 2
-                  description: e.g. student, programmer, architect
-                - id: on_feet
-                  created_at:
-                  updated_at:
-                  name: On your feet
-                  rank: 3
-                  description: e.g. physician, retail salesperson, tour guide
-                - id: driving
-                  created_at:
-                  updated_at:
-                  name: Driving around
-                  rank: 4
-                  description: e.g. pharmaceutical representative, taxi driver, truck
-                    driver
-                - id: working_with_hands
-                  created_at:
-                  updated_at:
-                  name: Working with your hands
-                  rank: 5
-                  description: e.g. farmer, fishery worker, landscaper
   "/api/day_habits/{id}":
     parameters:
     - name: id
@@ -1181,46 +100,12 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Bad request: id param is not a valid day_habit id'
   "/api/education_levels":
     get:
       summary: list education_levels
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                education_levels:
-                - id: less_than_hi_school
-                  created_at:
-                  updated_at:
-                  name: Less than high school
-                  rank: 1
-                - id: hi_school
-                  created_at:
-                  updated_at:
-                  name: High school diploma
-                  rank: 2
-                - id: college_degree
-                  created_at:
-                  updated_at:
-                  name: Some college or associate's degree
-                  rank: 3
-                - id: bachelors_degree
-                  created_at:
-                  updated_at:
-                  name: Bachelor's degree
-                  rank: 4
-                - id: advanced_degree
-                  created_at:
-                  updated_at:
-                  name: Advanced degree
-                  rank: 5
   "/api/education_levels/{id}":
     parameters:
     - name: id
@@ -1234,76 +119,12 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Bad request: id param is not a valid education_level id'
   "/api/ethnicities":
     get:
       summary: list ethnicities
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                ethnicities:
-                - id: latino
-                  created_at:
-                  updated_at:
-                  name: Latino or Hispanic
-                  rank: 1
-                - id: white
-                  created_at:
-                  updated_at:
-                  name: European or White
-                  rank: 2
-                - id: east_asian
-                  created_at:
-                  updated_at:
-                  name: East Asian
-                  rank: 3
-                - id: south_asian
-                  created_at:
-                  updated_at:
-                  name: South Asian
-                  rank: 4
-                - id: black
-                  created_at:
-                  updated_at:
-                  name: African American or Black
-                  rank: 5
-                - id: oceanian
-                  created_at:
-                  updated_at:
-                  name: Pacific Islander or Oceanian
-                  rank: 6
-                - id: middle_eastern
-                  created_at:
-                  updated_at:
-                  name: Middle Eastern or North African
-                  rank: 7
-                - id: native_american
-                  created_at:
-                  updated_at:
-                  name: Native American or Alaska Native
-                  rank: 8
-                - id: african
-                  created_at:
-                  updated_at:
-                  name: Sub-Saharan African
-                  rank: 9
-                - id: other
-                  created_at:
-                  updated_at:
-                  name: Other
-                  rank: 10
-                - id: not_sure
-                  created_at:
-                  updated_at:
-                  name: I'm not sure
-                  rank: 11
   "/api/ethnicities/{id}":
     parameters:
     - name: id
@@ -1317,22 +138,12 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Bad request: id param is not a valid ethnicity id'
   "/api/passwords":
     post:
       summary: create password
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: password'
   "/api/passwords/{id}":
     parameters:
     - name: id
@@ -1346,58 +157,27 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                password:
-                  id: '123'
-                  created_at: '2023-07-29T22:44:52.661Z'
-                  updated_at: '2023-07-29T22:44:52.671Z'
-                  email: user18@example.com
-                  reset_password_token: '123'
-                  current_password:
-                  password:
-                  password_confirmation:
     patch:
       summary: update password
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: password'
     put:
       summary: update password
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: password'
   "/api/posts":
     get:
       summary: list posts
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                posts: []
     post:
       summary: create post
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: post'
   "/api/posts/{id}":
     parameters:
     - name: id
@@ -1411,11 +191,6 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
   "/api/profiles":
     get:
       summary: list profiles
@@ -1435,94 +210,40 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
     patch:
       summary: update profile
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
     put:
       summary: update profile
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
   "/api/registrations/destroy":
     put:
       summary: delete registration
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
   "/api/registrations":
     post:
       summary: create registration
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: registration'
   "/api/searches":
     get:
       summary: show search
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                  resource:
-                  - can't be blank
-                  - is not included in the list
   "/api/sexes":
     get:
       summary: list sexes
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                sexes:
-                - id: male
-                  created_at:
-                  updated_at:
-                  name: Male
-                  rank: 1
-                - id: female
-                  created_at:
-                  updated_at:
-                  name: Female
-                  rank: 2
-                - id: other
-                  created_at:
-                  updated_at:
-                  name: Other
-                  rank: 3
-                - id: doesnt_say
-                  created_at:
-                  updated_at:
-                  name: Prefer not to say
-                  rank: 4
   "/api/sexes/{id}":
     parameters:
     - name: id
@@ -1536,11 +257,6 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Bad request: id param is not a valid sex id'
   "/api/symptoms/{id}":
     get:
       summary: show symptom
@@ -1556,15 +272,6 @@ paths:
           description: successful
           content:
             application/json:
-              example:
-                symptom:
-                  id: 1
-                  created_at: '2023-07-29T22:44:53.365Z'
-                  updated_at: '2023-07-29T22:44:53.365Z'
-                  type: symptom
-                  color_id:
-                  users_count: 0
-                  name: Symptom1
               schema:
                 type: object
                 properties:
@@ -1600,20 +307,11 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                tags: []
     post:
       summary: create tag
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: tag'
   "/api/tags/{id}":
     parameters:
     - name: id
@@ -1627,32 +325,17 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
   "/api/trackings":
     get:
       summary: list trackings
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: trackable_type'
     post:
       summary: create tracking
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: tracking'
   "/api/trackings/{id}":
     parameters:
     - name: id
@@ -1666,41 +349,23 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
     delete:
       summary: delete tracking
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
   "/api/treatments":
     get:
       summary: list treatments
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                treatments: []
     post:
       summary: create treatment
+      parameters: []
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: treatment'
   "/api/treatments/{id}":
     parameters:
     - name: id
@@ -1714,11 +379,6 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - Resource Not Found
   "/api/users/{id}":
     parameters:
     - name: id
@@ -1732,121 +392,18 @@ paths:
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                user:
-                  id: 44
-                  created_at: '2023-07-29T22:44:53.954Z'
-                  updated_at: '2023-07-29T22:44:53.966Z'
-                  email: user44@example.com
-                  intercom_hash: 1b72b549ef1f8a6f2badcc28b160b8e42d547ea019a2e01a5e0cdec805cb1038
-                  topic_following_id: 64c596650fabf076afb69632
-                  profile_id: 44
-                profiles:
-                - id: 44
-                  created_at: '2023-07-29T22:44:53.958Z'
-                  updated_at: '2023-07-29T22:44:53.958Z'
-                  screen_name:
-                  birth_date:
-                  country_id:
-                  sex_id:
-                  onboarding_step_id: onboarding-personal
-                  ethnicity_ids: []
-                  day_habit_id:
-                  education_level_id:
-                  day_walking_hours:
-                  pressure_units: mb
-                  temperature_units: f
-                  beta_tester: false
-                  notify_token: 436550160eed6aa631b6947f8c84ed89
-                  notify: true
-                  checkin_reminder: true
-                  checkin_reminder_at:
-                    hours: 20
-                    minutes: 0
-                  time_zone_name: America/New_York
-                  notify_top_posts: true
     patch:
       summary: update user
       parameters: []
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                user:
-                  id: 45
-                  created_at: '2023-07-29T22:44:54.029Z'
-                  updated_at: '2023-07-29T22:44:54.066Z'
-                  email: updatedemail@example.com
-                  intercom_hash: 7ab8b7681a8d33388b86b73953e0df9e6305458416f3a5293ca0ca37335a3328
-                  topic_following_id: 64c596660fabf076afb69633
-                  profile_id: 45
-                profiles:
-                - id: 45
-                  created_at: '2023-07-29T22:44:54.032Z'
-                  updated_at: '2023-07-29T22:44:54.032Z'
-                  screen_name:
-                  birth_date:
-                  country_id:
-                  sex_id:
-                  onboarding_step_id: onboarding-personal
-                  ethnicity_ids: []
-                  day_habit_id:
-                  education_level_id:
-                  day_walking_hours:
-                  pressure_units: mb
-                  temperature_units: f
-                  beta_tester: false
-                  notify_token: 743ad1a9a5340b98725f5f3e343c9bec
-                  notify: true
-                  checkin_reminder: true
-                  checkin_reminder_at:
-                    hours: 20
-                    minutes: 0
-                  time_zone_name: America/New_York
-                  notify_top_posts: true
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                user:
-                  type: object
-                  properties:
-                    email:
-                      type: string
-              required:
-              - user
-            examples:
-              request_example_1:
-                summary: A request example
-                value:
-                  user:
-                    email: updatedemail@example.com
-    put:
-      summary: update user
-      responses:
-        '200':
-          description: successful
-          content:
-            application/json:
-              example:
-                errors:
-                - 'Required parameter missing: user'
   "/api/weathers":
     get:
       summary: list weathers
       responses:
         '200':
           description: successful
-          content:
-            application/json:
-              example:
-                weathers: []
 servers:
 - url: http://localhost:3000
   description: local documentation


### PR DESCRIPTION
# Overview
Adds the [rswag gem](https://github.com/rswag/rswag) and generates the default specs for the existing controllers. This generates interactive documentation to view the Open API Documentation for the endpoints.

## Notes
- All the specs generated have been marked as pending, as they need to be filled in with correct details. These specs will actually hit the controller in order to generate the example data and will fail if they do not receive the correct response. Ideally future contributors to the repo can work incrementally on each spec to generate this example data. 