### PR TITLE
Lock npm version in frontend so deployments work

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,7 @@
   "engines": {
     "bower": "1.x",
     "node": "12.22.6",
-    "npm": ">=7.0.0"
+    "npm": "7.x"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
Got the same dreaded error that npm@9 is too new for node v12 when deploying to Heroku, just like we did for the CI process during RubyForGood.

Solution is the same -- lock npm to v7 in the package.json file this time -- just like the CI step.