### PR TITLE
Setup and execute in development using docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ Help would be appreciated! Please join us in [slack #flaredown](https://rubyforg
 * Redis 6.2.3
 * Ruby 3.0.6 (see [RVM](https://rvm.io/) also)
 * Node 12.22.6
+
 ## Installation
+
+All dependencies are dockerized, including the application and can be run using `docker compose` so there's no dependencies to install other than docker.
+
+If you want to run the application on your own machine see the next sections on dependency installations
+
+### Mac
 
 _If you are running on an M1 mac, run the following command before you start the installation process:_
 ```bash
@@ -54,7 +61,22 @@ npm install
 
 ## Running / Development
 
+### Docker
+
 From the project root:
+
+```bash
+docker compose --profile dev up
+```
+
+This will build and run all the containers necessary to run the application locally.
+
+Visit your app at [http://localhost:4300](http://localhost:4300)
+
+### Local Machine Installation
+
+From the project root:
+
 ```bash
 docker compose up
 ```
@@ -62,8 +84,6 @@ docker compose up
 ```bash
 rake run
 ```
-
-Visit your app at [http://localhost:4300](http://localhost:4300)
 
 ## CI
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:3.0
+
+# set working directory
+WORKDIR /app
+
+# install dependencies
+RUN apt-get update -qq && \
+      apt-get install -y nodejs postgresql-client
+
+# install bundler
+RUN gem install bundler:2.1.4
+
+# copy the Gemfile and Gemfile.lock to the container
+COPY Gemfile Gemfile.lock ./
+
+# install the gems
+RUN bundle install
+
+# copy the rest of the application files to the container
+COPY . .
+
+# start the server
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: localhost
+  host: <%= ENV.fetch('PG_DATABASE_HOST') { 'localhost' } %>
   database: flaredown_development
   username: postgres
   password: password

--- a/backend/config/mongoid.yml
+++ b/backend/config/mongoid.yml
@@ -9,7 +9,7 @@ development:
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - localhost:27017
+        - <%= ENV['MONGODB_HOST'] || "localhost" %>:27017
       options:
         # Change the default write concern. (default = { w: 1 })
         # write:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,87 @@
-version: '3'
-volumes:
-  postgres:
-  mongodb:
-  redis:
+version: '3.8'
+x-backend-services-hosts:
+  &backend-services-hosts
+  MONGODB_HOST: mongodb
+  REDIS_URL: redis://redis:6379
+  PG_DATABASE_HOST: postgres
+
 services:
+  backend:
+    build: backend
+    depends_on:
+      - postgres
+      - mongodb
+      - redis
+    ports:
+      - 3000:3000
+    volumes:
+      - ./backend:/app
+    environment: *backend-services-hosts
+    profiles:
+      - dev
+  workers:
+    build: backend
+    command: bundle exec sidekiq -C config/sidekiq.yml
+    depends_on:
+      - redis
+      - mongodb
+      - postgres
+    volumes:
+      - ./backend:/app
+    environment: *backend-services-hosts
+    profiles:
+      - dev
+  tunnel:
+    build: backend
+    command: bundle exec bin/localtunnel
+    depends_on:
+      - backend
+    volumes:
+      - ./backend:/app
+    profiles:
+      - tunnel
+  frontend:
+    build: frontend
+    depends_on:
+      - backend
+    ports:
+      - 4300:4300
+    volumes:
+      - ./frontend:/app
+    command: sh -c "cd /app && rm -rfd ./dist && ./node_modules/.bin/ember serve --port 4300 --proxy http://localhost:3000"
+    profiles:
+      - dev
+  app-setup:
+    build: backend
+    command: bundle exec rails app:setup
+    depends_on:
+      - postgres
+    environment: *backend-services-hosts
+    profiles:
+      - tools
   postgres:
     image: postgres:12.8-alpine
+    restart: always
     environment:
       POSTGRES_PASSWORD: password
       PGDATA: /data
     volumes:
       - postgres:/data
-    ports:
-      - 5432:5432
+    expose:
+      - 5432
   mongodb:
     image: mongo:4.4.9
     volumes:
       - mongodb:/data/db
-    ports:
-      - 27017:27017
+    expose:
+      - 27017
   redis:
     image: redis:6.2.3-alpine
     volumes:
       - redis:/data
-    ports:
-      - 6379:6379
+    expose:
+      - 6379
+volumes:
+  postgres:
+  mongodb:
+  redis:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+bower_components
+node_modules
+dist
+tmp
+.git
+README.md
+LICENSE
+.gitignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:12.22.6
+
+# Force npm version 7
+RUN npm i -g npm@7
+
+WORKDIR /app
+
+COPY package*.json node_modules bower.json .bowerrc .npmrc ./
+
+RUN npm install
+
+COPY . .
+
+# Rebuild node-sass for the current environment
+RUN npm rebuild node-sass
+
+CMD ["npm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,4 @@ RUN npm install
 
 COPY . .
 
-# Rebuild node-sass for the current environment
-RUN npm rebuild node-sass
-
 CMD ["npm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,7 @@ RUN npm i -g npm@7
 
 WORKDIR /app
 
-COPY package*.json node_modules bower.json .bowerrc .npmrc ./
+COPY package*.json bower.json .bowerrc .npmrc ./
 
 RUN npm install
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,7 +23,7 @@ You will need the following things properly installed on your computer.
 ## Running / Development
 
 * `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your app at [http://localhost:4300](http://localhost:4300).
 
 ## Running / Development via Fastboot server
 
@@ -54,4 +54,3 @@ Specify what it takes to deploy your app.
 * Development Browser Extensions
   * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
   * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
-


### PR DESCRIPTION
This change will allow us to run the application using

```
docker compose --profile dev up
```

and doesn't require us to install anything in our host machine. 


## Caveat

Since I didn't want to modify the existing `docker-compose` flow. I used the `dev` profile to ensure we're opting in to the new development flow.

This means for tearing down the containers after use you have to remember to use `docker compose --profile dev down` rather than just `docker compose down`.

Another option would be to add the `--profile databases` to the DB dependencies and allow `docker compose up` to spin up a entire dev environment by default. 


I'm also not sure why but the frontend service takes quite a bit to spin up ember and serve traffic, not sure if this is also the case for the local machine installation.