### PR TITLE
Fixup connection refused errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - 4300:4300
     volumes:
       - ./frontend:/app
-    command: sh -c "cd /app && rm -rfd ./dist && ./node_modules/.bin/ember serve --port 4300 --proxy http://localhost:3000"
+    command: sh -c "cd /app && rm -rfd ./dist && ./node_modules/.bin/ember serve --port 4300 --proxy http://backend:3000"
     profiles:
       - dev
   app-setup:


### PR DESCRIPTION
When starting the development setup through docker-compose, the logs would display an ERRCONNREFUSED but this doesn't seem to have any effect on development. However changing the proxy to point to the internal backend service name from the docker network seems to fix these and continues to let things work as expected