### PR TITLE
Add M1 support and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dump.rdb
 .rbenv-gemsets
 
 .idea/*
+.bundle
+frontend/.env

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ npm install
 
 ## Running / Development
 
+### General
+It is necessary to populate environment parameters. You can take `backend/env-example` and add it to a new file in `backend/.env` and `frontend/.env`. You'll need to create a [Facebook dev app](https://developers.facebook.com/docs/development/create-an-app) and paste your own ID the frontend env file's `FACEBOOK_APP_ID` parameter. This is not necessary in the backend env but we have not yet cleaned up these two files into the necessary components.
+
 ### Docker
 
 From the project root:
@@ -104,6 +107,8 @@ Addons are used for Heroku Postgres, Heroku Redis, Heroku Scheduler + Papertrail
 
 ### 🎨 [Figma Assets](https://www.figma.com/proto/MBVn73pD6JbBkxd65KSZHr/Flaredown-Guide?page-id=0%3A1&node-id=1%3A3&viewport=241%2C48%2C0.45&scaling=contain&starting-point-node-id=1%3A3)
 
+## Common Problems
+* On first load, the app displays a blank beige screen instead of the login screen. Temporary fix is to add  `console.log(process.env.FACEBOOK_APP_ID)` right inside of the module.exports at the top of the `frontend/config/environment.js` file. You can then refresh the page (no need to kill Docker) and this should fix it. You can now remove the log.
 
 ## License
 Copyright 2015-2017 Logan Merriam and contributors.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     profiles:
       - tunnel
   frontend:
+    platform: linux/amd64
     build: frontend
     depends_on:
       - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.6
+FROM --platform=linux/amd64 node:12.22.6
 
 # Force npm version 7
 RUN npm i -g npm@7


### PR DESCRIPTION
ARM based computers such as Apple's M1 chip were not previously supported by the dev loop. Specifically, the PhantomJS dependency is deprecated and therefore was never updated to support M1 architecture. We can bypass this for now by telling Docker to build on x86 architecture but a more long term solution would be to replace the PhantomJS dependency with something that is still maintained and has M1 support.