### PR TITLE
Replace bower's spinkit with npm

### DIFF
--- a/frontend/app/styles/spinner.scss
+++ b/frontend/app/styles/spinner.scss
@@ -1,5 +1,3 @@
-$spinkit-spinner-margin: 40px auto !default;
-$spinkit-size: 40px !default;
-$spinkit-spinner-color: $primary !default;
-
-@import 'spinners/7-three-bounce';
+:root {
+  --sk-color: #{$primary};
+}

--- a/frontend/app/templates/application-loading.hbs
+++ b/frontend/app/templates/application-loading.hbs
@@ -1,5 +1,5 @@
-<div class="sk-three-bounce">
-  <div class="sk-child sk-bounce1"></div>
-  <div class="sk-child sk-bounce2"></div>
-  <div class="sk-child sk-bounce3"></div>
+<div class="sk-flow sk-center">
+  <div class="sk-flow-dot"></div>
+  <div class="sk-flow-dot"></div>
+  <div class="sk-flow-dot"></div>
 </div>

--- a/frontend/app/templates/application/three-bounce-spinner.hbs
+++ b/frontend/app/templates/application/three-bounce-spinner.hbs
@@ -1,5 +1,5 @@
-<div class="sk-three-bounce">
-  <div class="sk-child sk-bounce1"></div>
-  <div class="sk-child sk-bounce2"></div>
-  <div class="sk-child sk-bounce3"></div>
+<div class="sk-flow sk-center">
+  <div class="sk-flow-dot"></div>
+  <div class="sk-flow-dot"></div>
+  <div class="sk-flow-dot"></div>
 </div>

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "flaredown",
   "dependencies": {
-    "spinkit": "~1.2",
     "bourbon": "4.2.3",
     "neat": "~1.7.2",
     "pace": "vectart/pace",

--- a/frontend/ember-cli-build.js
+++ b/frontend/ember-cli-build.js
@@ -13,12 +13,6 @@ module.exports = function(defaults) {
       }
     },
 
-    sassOptions: {
-      includePaths: [
-        'bower_components/spinkit/scss'
-      ]
-    },
-
     fingerprint: {
       exclude: [
         'weather/clear-day',
@@ -60,6 +54,9 @@ module.exports = function(defaults) {
   });
 
   vendorLib = map(vendorLib, (content) => `if (typeof FastBoot === 'undefined') { ${content} \n }`);
+
+  // Spinkit
+  app.import('node_modules/spinkit/spinkit.css')
 
   // d3
   app.import(app.bowerDirectory + '/d3/d3.min.js');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "spinkit": "^2.0.1"
+      },
       "devDependencies": {
         "active-model-adapter": "^2.2.0",
         "bower": "^1.8.14",
@@ -20508,6 +20511,11 @@
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
+    "node_modules/spinkit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/spinkit/-/spinkit-2.0.1.tgz",
+      "integrity": "sha512-oYBGY0GV1H1dX+ZdKnB6JVsYC1w/Xl20H111eb+WSS8nUYmlHgGb4y5buFSkzzceEeYYh5kMhXoAmoTpiQauiA=="
+    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
@@ -39464,6 +39472,11 @@
       "version": "3.0.11",
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
+    },
+    "spinkit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/spinkit/-/spinkit-2.0.1.tgz",
+      "integrity": "sha512-oYBGY0GV1H1dX+ZdKnB6JVsYC1w/Xl20H111eb+WSS8nUYmlHgGb4y5buFSkzzceEeYYh5kMhXoAmoTpiQauiA=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,5 +81,8 @@
       "lib/full-story",
       "lib/heap-analytics"
     ]
+  },
+  "dependencies": {
+    "spinkit": "^2.0.1"
   }
 }


### PR DESCRIPTION
Ref: https://github.com/rubyforgood/Flaredown/issues/577

In the spirit of upgrading to future Ember versions, this PR drops spinkit's bower dependency and replaces it with npm while keeping the same functionality


https://github.com/rubyforgood/Flaredown/assets/1507561/cfd78da6-4238-49f5-becc-005b3dced7f0

