### PR TITLE
Move from authorizers to authorize function

### DIFF
--- a/frontend/app/adapters/application.js
+++ b/frontend/app/adapters/application.js
@@ -3,9 +3,15 @@ import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 import ENV from 'flaredown/config/environment';
 
 export default ActiveModelAdapter.extend(DataAdapterMixin, {
-  authorizer: 'authorizer:devise',
   host: ENV.apiHost,
   namespace: 'api',
-  coalesceFindRequests: true
+  coalesceFindRequests: true,
+  // defaults
+  // identificationAttributeName: 'email'
+  // tokenAttributeName: 'token'
+  authorize(xhr) {
+    let { email, token } = this.get('session.data.authenticated');
+    let authData = `Token token="${token}", email="${email}"`;
+    xhr.setRequestHeader('Authorization', authData);
+  }
 });
-


### PR DESCRIPTION
authorizers were deprecated and removed in v2 of ember-simple-auth. This is a pretty old version of the addon but doing these small upgrades should help in the long run

https://github.com/mainmatter/ember-simple-auth/tree/1.9.2#deprecation-of-authorizers