### PR TITLE
Migrate drag-drop-polyfill to npm

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -18,7 +18,6 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/pace/pace.js"></script>
-    <script src="{{rootURL}}assets/drag-drop-polyfill/release/drag-drop-polyfill.js"></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
 
     <script src="{{rootURL}}assets/flaredown.js"></script>

--- a/frontend/app/instance-initializers/drag-drop-polyfill.js
+++ b/frontend/app/instance-initializers/drag-drop-polyfill.js
@@ -1,6 +1,10 @@
+import {polyfill} from "mobile-drag-drop";
+import {scrollBehaviourDragImageTranslateOverride} from "mobile-drag-drop/scroll-behaviour";
+
 export function initialize() {
   if (typeof FastBoot === 'undefined') {
-    window.DragDropPolyfill.Initialize({
+    polyfill({
+      dragImageTranslateOverride: scrollBehaviourDragImageTranslateOverride,
       dragImageOffset: { x: 20, y: 0 }
     });
   }

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -5,7 +5,6 @@
     "neat": "~1.7.2",
     "pace": "vectart/pace",
     "d3": "~3.5.13",
-    "drag-drop-polyfill": "2.0.0-beta.1",
     "pickadate": "^3.5.6",
     "At.js": "^1.5.4"
   }

--- a/frontend/ember-cli-build.js
+++ b/frontend/ember-cli-build.js
@@ -55,7 +55,6 @@ module.exports = function(defaults) {
   let vendorLib = new Funnel(assetPath, {
     files: [
       '/pace/pace.js',
-      '/drag-drop-polyfill/release/drag-drop-polyfill.js',
     ],
     destDir: '/assets',
   });
@@ -69,9 +68,8 @@ module.exports = function(defaults) {
   app.import(app.bowerDirectory + '/d3/d3.min.js');
 
   // HTML5 Drag and Drop Polyfill for Mobile
-  app.import(app.bowerDirectory + '/drag-drop-polyfill/release/drag-drop-polyfill-scroll-behaviour.js');
-  app.import(app.bowerDirectory + '/drag-drop-polyfill/release/drag-drop-polyfill.css');
-  app.import(app.bowerDirectory + '/drag-drop-polyfill/release/drag-drop-polyfill-icons.css');
+  app.import('node_modules/mobile-drag-drop/default.css')
+  app.import('node_modules/mobile-drag-drop/icons.css')
 
   // At-js
   app.import(app.bowerDirectory + '/At.js/dist/css/jquery.atwho.css');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "mobile-drag-drop": "^2.2.0",
         "moment": "^2.29.4",
         "moment-range": "^4.0.2",
         "moment-timezone": "^0.5.43",
@@ -19303,6 +19304,11 @@
       "engines": {
         "node": ">0.9"
       }
+    },
+    "node_modules/mobile-drag-drop": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mobile-drag-drop/-/mobile-drag-drop-2.2.0.tgz",
+      "integrity": "sha512-SbYUySukoQryFrIkpR4S70QOyr3WD90raxiEHHaH9Bwg6O7fbMlpB4ANlNUkQ/j05YtWPm/PWnjPAXotXB8bIA=="
     },
     "node_modules/moment": {
       "version": "2.29.4",
@@ -40978,6 +40984,11 @@
       "version": "0.4.0",
       "integrity": "sha512-IXnMcJ6ZyTuhRmJSjzvHSRhlVPiN9Jwc6e59V0bEJ0ba6OBeX2L0E+mRN1QseeOF4mM+F1Rit6Nh7o+rl2Yn/A==",
       "dev": true
+    },
+    "mobile-drag-drop": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mobile-drag-drop/-/mobile-drag-drop-2.2.0.tgz",
+      "integrity": "sha512-SbYUySukoQryFrIkpR4S70QOyr3WD90raxiEHHaH9Bwg6O7fbMlpB4ANlNUkQ/j05YtWPm/PWnjPAXotXB8bIA=="
     },
     "moment": {
       "version": "2.29.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -84,6 +84,7 @@
     ]
   },
   "dependencies": {
+    "mobile-drag-drop": "^2.2.0",
     "moment": "^2.29.4",
     "moment-range": "^4.0.2",
     "moment-timezone": "^0.5.43",


### PR DESCRIPTION
🔥 less bower more npm

- The package was renamed after version 2.0.0.rc to mobile-drag-drop
- CSS files were renamed as well

Ref: https://github.com/rubyforgood/Flaredown/issues/577

* Tested locally by adding a few items to a checkin and being able to drag/drop them both in desktop and mobile views