### PR TITLE
Revert "Bump puma from 5.6.7 to 6.4.2 in /backend"

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -17,7 +17,7 @@ gem "mongoid", "7.3.3"
 gem "pg", "1.2.3"
 
 # Use Puma as the app server
-gem "puma", "6.4.2"
+gem "puma", "5.6.8"
 
 # Authentication libraries
 gem "cancancan", "~> 3.3.0"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -313,9 +313,9 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.3)
-    puma (6.4.2)
+    puma (5.6.8)
       nio4r (~> 2.0)
-    puma (6.4.2-java)
+    puma (5.6.8-java)
       nio4r (~> 2.0)
     pusher (2.0.2)
       httpclient (~> 2.8)
@@ -523,7 +523,7 @@ DEPENDENCIES
   pry-byebug
   pry-doc
   pry-rails
-  puma (= 6.4.2)
+  puma (= 5.6.8)
   pusher
   rack-cors (= 2.0.1)
   rack-timeout


### PR DESCRIPTION
Reverts rubyforgood/Flaredown#708