### PR TITLE
Revert "Bump rack from 2.2.8 to 2.2.8.1 in /backend"

### DIFF
--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -324,7 +324,7 @@ GEM
     pusher-signature (0.1.8)
     racc (1.7.3)
     racc (1.7.3-java)
-    rack (2.2.8.1)
+    rack (2.2.8)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-test (2.1.0)


### PR DESCRIPTION
Reverts rubyforgood/Flaredown#725