### PR TITLE
Point the README CI badges at workflows that exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Flaredown
-[![rspec](https://github.com/rubyforgood/Flaredown/actions/workflows/rspec.yml/badge.svg)](https://github.com/rubyforgood/Flaredown/actions/workflows/rspec.yml)
+[![backend](https://github.com/rubyforgood/Flaredown/actions/workflows/backend.yml/badge.svg)](https://github.com/rubyforgood/Flaredown/actions/workflows/backend.yml)
 [![frontend](https://github.com/rubyforgood/Flaredown/actions/workflows/frontend.yml/badge.svg)](https://github.com/rubyforgood/Flaredown/actions/workflows/frontend.yml)
-[![ERB lint](https://github.com/rubyforgood/Flaredown/actions/workflows/erb_lint.yml/badge.svg)](https://github.com/rubyforgood/Flaredown/actions/workflows/erb_lint.yml)
-[![standardrb lint](https://github.com/rubyforgood/Flaredown/actions/workflows/ruby_lint.yml/badge.svg)](https://github.com/rubyforgood/Flaredown/actions/workflows/ruby_lint.yml)
+[![native](https://github.com/rubyforgood/Flaredown/actions/workflows/native.yml/badge.svg)](https://github.com/rubyforgood/Flaredown/actions/workflows/native.yml)
 
 Flaredown makes it easy for people to track symptoms over time, and learn how to control them. Our goal is to analyze the aggregate data from users of this tool to understand the probable effects of treatments and environmental stressors on chronic illness.
 


### PR DESCRIPTION
Three of the four CI badges in the README point at workflow files that no longer exist, so they render as "no status" rather than a build result.

They were removed in #520 (`1fd910f2`, 2021-10-14), "Combines backend CI jobs into single workflow", which replaced them with `backend.yml`. The badges were not updated at the time.

| Badge | Workflow path | Rendered as |
| --- | --- | --- |
| rspec | `rspec.yml` | `rspec - no status` |
| frontend | `frontend.yml` | `frontend - failing` |
| ERB lint | `erb_lint.yml` | `ERB lint - no status` |
| standardrb lint | `ruby_lint.yml` | `standardrb lint - no status` |

### Why four badges become three

Badges are per *workflow*, not per job. `rspec`, `erb-lint` and `standardrb` are now three jobs inside `backend.yml`, so there is no URL that reports them separately — one `backend` badge covers all three. That leaves room for `native.yml`, which never had one, so all three workflows in the repo are now represented.

I checked the images and the links they wrap rather than assuming the URLs were right:

```
backend    backend - passing    HTTP 200
frontend   frontend - failing   HTTP 200
native     native - passing     HTTP 200
```

### One thing to expect

This makes the README show a red badge, because `frontend` genuinely is failing on `master`. That is already being fixed in #868. This change does not cause it — it stops three blank badges from hiding it.

Fixes #745. Merges cleanly with #868; no overlap with #870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
