### PR TITLE
Filter checkins by date in Mongo instead of in Ruby

### DIFF
--- a/backend/app/controllers/api/v1/checkins_controller.rb
+++ b/backend/app/controllers/api/v1/checkins_controller.rb
@@ -7,9 +7,10 @@ module Api
         if date.blank? && params.require(:page)
           render json: current_user.checkins.where(:note.nin => [nil, ""]).order_by(date: :desc).page(params[:page]).per(10)
         else
-          render json: current_user.checkins.includes([:harvey_bradshaw_index, :promotion_rate, :conditions, :symptoms, :treatments]).select { |x|
-            x.date.to_date == Date.parse(date)
-          }
+          day = Date.parse(date)
+          checkins = current_user.checkins.by_date(day.beginning_of_day, day.end_of_day)
+          # to_a so the criteria is loaded and eager loaded once, not once per serializer pass
+          render json: checkins.includes([:harvey_bradshaw_index, :promotion_rate, :conditions, :symptoms, :treatments]).to_a
         end
       end
 

--- a/backend/spec/controllers/api/v1/checkins_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/checkins_controller_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe Api::V1::CheckinsController do
         returned_checkin = response_body[:checkins][0]
         expect(Date.parse(returned_checkin[:date])).to eq Date.parse(date)
       end
+
+      it "filters by date in the database instead of loading every checkin" do
+        commands = capture_mongo_commands { get :index, params: {date: date} }
+
+        checkin_finds = commands.select { |command| command.command["find"] == "checkins" }
+
+        expect(checkin_finds.size).to eq 1
+        expect(checkin_finds.first.command["filter"]["date"].keys).to match_array ["$gte", "$lte"]
+      end
     end
     context "when checkin doesn't exist for the passed date" do
       it "returns no results" do

--- a/backend/spec/support/mongo_commands.rb
+++ b/backend/spec/support/mongo_commands.rb
@@ -1,0 +1,39 @@
+# Captures the commands the Mongo driver sends while a block runs, so specs can
+# assert that filtering happens in the database rather than in Ruby.
+module MongoCommands
+  class Subscriber
+    attr_reader :commands
+
+    def initialize
+      @commands = []
+    end
+
+    def started(event)
+      @commands << event
+    end
+
+    def succeeded(event)
+    end
+
+    def failed(event)
+    end
+  end
+
+  def capture_mongo_commands
+    subscriber = Subscriber.new
+    client = Mongoid.default_client
+    client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+
+    begin
+      yield
+    ensure
+      client.unsubscribe(Mongo::Monitoring::COMMAND, subscriber)
+    end
+
+    subscriber.commands
+  end
+end
+
+RSpec.configure do |config|
+  config.include MongoCommands, type: :controller
+end


### PR DESCRIPTION
Closes #874.

## The bug

`CheckinsController#index` called `.select` with a block on the criteria. That is `Enumerable#select`, not `Mongoid::Criteria#select`, so it forced the criteria to load: every check-in the user had ever created came back from Mongo, along with the eager loaded associations for all of them, and everything outside the requested day was then thrown away in Ruby.

This is the endpoint the web and native clients hit to render a single day, so the cost grew with account age on one of the hottest paths in the app — and it grew fastest for the longest-tenured users.

## The fix

Use the `by_date` scope that already exists on `Checkin` over the requested day's bounds, so the query is served by the existing `index(date: 1, encrypted_user_id: 1)`. Both the scope and the index were already there and simply were not being used here.

The resulting query:

```
{"find"=>"checkins",
 "filter"=>{"encrypted_user_id"=>"…",
            "date"=>{"$gte"=>2016-01-06 00:00:00 UTC,
                     "$lte"=>2016-01-06 23:59:59.999999999 UTC}}}
```

### Why the `.to_a`

It looks like a no-op and isn't, which is why it carries a comment. Rendering the bare criteria makes AMS enumerate it more than once, re-running both the query and the eager loads. Measured against a user with 60 days of history, counting actual driver commands:

| Variant | Mongo commands | `checkins` finds | Filter in DB? | Docs returned |
|---|---|---|---|---|
| `select {}` (before) | 14 | 1 | no | 60 |
| `by_date` criteria | 20 | 2 | yes | 1 |
| `by_date` + `to_a` | **14** | **1** | **yes** | **1** |

So `to_a` keeps the command count identical to the original while moving the filter into the database.

## Test

The existing specs passed against the buggy code — the output was correct, just expensively obtained — which is how this survived. A behaviour-only test cannot catch it, so `spec/support/mongo_commands.rb` adds a small driver-monitoring subscriber, and the new example asserts there is exactly one `checkins` find and that it carries a `$gte`/`$lte` date filter. It fails if Ruby-side filtering returns or the `to_a` is dropped.

## Behaviour note

`Date.parse` used to be called inside the block, so an invalid `date` param returned `200 []` for a user with no check-ins but raised for everyone else. It now raises consistently (422 in production via `rescue_from "Exception"`). More consistent, but it is a change, so worth calling out.

## Verification

Full backend suite green (316 examples, 0 failures), `standardrb` clean, `erblint --lint-all` clean.

One unrelated thing noticed while verifying: `spec/models/food_spec.rb:35` is flaky on master (1 in 20 full-suite runs for me). `Food.fts` orders by `ts_rank_cd(...) DESC` with no tie-breaker, and the spec asserts an exact order for two rows that rank equal. It passes 25/25 in isolation and only varies in full-suite runs. Not touched here and not caused by this change — measured at 1/20 on master and 0/20 on this branch — but mentioning it in case CI goes red on it.
