### PR TITLE
Give Food.fts a deterministic order

### DIFF
--- a/backend/app/models/food.rb
+++ b/backend/app/models/food.rb
@@ -46,7 +46,7 @@ class Food < ActiveRecord::Base
           ) OR foods.global IS TRUE
         ) f
         WHERE f.searchable @@ to_tsquery(:lang, :query)
-        ORDER BY ts_rank_cd(f.searchable, to_tsquery(:lang, :query), 1) DESC
+        ORDER BY ts_rank_cd(f.searchable, to_tsquery(:lang, :query), 1) DESC, f.id ASC
         LIMIT :limit
       SQL
     end

--- a/backend/spec/models/food_spec.rb
+++ b/backend/spec/models/food_spec.rb
@@ -9,9 +9,22 @@ RSpec.describe Food do
   end
 
   describe "class methods" do
+    # Descriptors are fixed rather than FFaker::Lorem.word, and chosen so the three
+    # global rows rank distinctly. Two independent hazards otherwise:
+    #
+    #   1. FFaker::Lorem::WORDS contains "a", "at" and "in", which the english text
+    #      search config strips as stopwords. "TestFood at" then has the tsvector
+    #      'testfood':1 and ranks 0.14426951 -- the same as a bare "TestFood" --
+    #      instead of 0.09102392, which reorders the result. Roughly a 3% chance per
+    #      run across the two draws.
+    #   2. Equal ranks left the ordering to Postgres, which is free to return tied
+    #      rows in any order.
+    #
+    # "TestFood alpha" ranks 0.09102392 and "TestFood alpha bravo" 0.072134756, so
+    # these expectations rest on relevance alone and not on tie-break behaviour.
     let!(:global_food) { create(:food, long_desc: "TestFood") }
-    let!(:same_food_1) { create(:food, long_desc: "TestFood #{FFaker::Lorem.word}") }
-    let!(:same_food_2) { create(:food, long_desc: "TestFood #{FFaker::Lorem.word}") }
+    let!(:same_food_1) { create(:food, long_desc: "TestFood alpha") }
+    let!(:same_food_2) { create(:food, long_desc: "TestFood alpha bravo") }
 
     let!(:personal_food) { create(:food, :personal, long_desc: "TestFood") }
     let!(:user_food) { create(:user_food, food: personal_food) }
@@ -33,6 +46,17 @@ RSpec.describe Food do
 
       it "retrun local and global foods for author" do
         expect(Food.send(:fts, query[:name], MAX_ROWS, user_food.user_id)).to eq [global_food, personal_food]
+      end
+
+      it "returns equally ranked foods in a stable order" do
+        # Identical descriptions rank identically, so ts_rank_cd cannot separate these.
+        # The `f.id ASC` tie-breaker in fts_sql decides the order; without it Postgres
+        # is free to return tied rows however the heap happens to be laid out, which is
+        # what made this file order-dependent in full-suite runs.
+        tied_a = create(:food, long_desc: "TiedFood")
+        tied_b = create(:food, long_desc: "TiedFood")
+
+        expect(Food.send(:fts, "TiedFood", 2, user_food.user_id)).to eq [tied_a, tied_b]
       end
     end
   end


### PR DESCRIPTION
Closes #876.

## The ordering bug

`fts_sql` ordered by relevance alone:

```sql
ORDER BY ts_rank_cd(f.searchable, to_tsquery(:lang, :query), 1) DESC
LIMIT :limit
```

Where several foods rank equally, Postgres is free to return them in whatever order the heap happens to be laid out. With `LIMIT`, that means the *same* search can return a different set and a different order on each request — a user-visible defect in food search, not only a test problem. Adding `f.id ASC` as a secondary sort key fixes both.

Demonstrated directly, with two equally-ranked rows where the first is updated so MVCC rewrites it at the end of the heap:

```
without tie-breaker: [2, 1]
with    tie-breaker: [1, 2]
```

## A second cause, not in the issue

The issue attributes the flake entirely to heap ordering. There is a second, independent cause, and the tie-breaker alone would not have fixed it.

The two `same_food_*` fixtures used `FFaker::Lorem.word`. `FFaker::Lorem::WORDS` contains **"a", "at" and "in"** — all stopwords under the `english` search configuration. When one is drawn, the row's tsvector loses its second lexeme:

| `long_desc` | tsvector | `ts_rank_cd` |
|---|---|---|
| `TestFood` | `'testfood':1` | 0.14426951 |
| `TestFood lorem` | `'lorem':2 'testfood':1` | 0.09102392 |
| `TestFood at` | `'testfood':1` | **0.14426951** |

So `"TestFood at"` ranks identically to a bare `"TestFood"` and displaces it in the results, whatever the tie-breaker does. Three stopwords in a 182-word list, across two draws, is **~3.3% per run** — close to the 1-in-20 rate the issue measured.

Forcing a stopword into one fixture reproduces the reported failure **every time**, which is what confirmed the mechanism.

## What changed

- `f.id ASC` tie-breaker in `fts_sql`
- Fixture descriptors are fixed values chosen to rank distinctly: `"TestFood alpha"` (0.09102392) and `"TestFood alpha bravo"` (0.072134756). Those two expectations now rest on relevance alone and would still hold if the tie-breaker were removed — the point being that they test ranking, not ordering.
- Tie-break behaviour gets its own example, using two foods with identical descriptions, so the new sort key is covered deliberately rather than incidentally.

## Verification

- **10 consecutive full-suite runs, 0 failures** (316 examples). The issue measured 1 failure in 20 runs on `master`, so this is suggestive rather than conclusive on its own — the deterministic reproduction above is the stronger evidence.
- `standardrb`, `erblint` clean. Brakeman 4 warnings / 0 errors, unchanged from `master`.

## Note

Independent of #889 (upgrade prep) — different files, no conflict in either order. Worth landing before the Rails version bumps begin, so a red CI run during those can be read as a real regression rather than this flake.
