### PR TITLE
Upgrade Globalize to 7.1.3 and Puma to 6.6.1

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -46,7 +46,7 @@ gem "countries", require: "countries/global"
 gem "pusher"
 
 # ActiveRecord data translations
-gem "globalize"
+gem "globalize", "~> 7.1"
 
 # Abort requests that are taking too long
 gem "rack-timeout"

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -20,7 +20,7 @@ gem "mongoid", "9.0.11" # https://www.mongodb.com/docs/mongoid/current/reference
 gem "pg"
 
 # Use Puma as the app server
-gem "puma", "5.6.8"
+gem "puma", "~> 6.6"
 
 # Authentication libraries
 gem "cancancan", "~> 3.6.1"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -297,7 +297,7 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
-    nio4r (2.7.3)
+    nio4r (2.7.5)
     nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -341,7 +341,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (5.6.8)
+    puma (6.6.1)
       nio4r (~> 2.0)
     pusher (2.0.3)
       httpclient (~> 2.8)
@@ -554,7 +554,7 @@ DEPENDENCIES
   pry-byebug
   pry-doc
   pry-rails
-  puma (= 5.6.8)
+  puma (~> 6.6)
   pusher
   rack-cors (= 2.0.1)
   rack-timeout

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -216,9 +216,10 @@ GEM
       csv (>= 3.0.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    globalize (6.3.0)
-      activemodel (>= 4.2, < 7.2)
-      activerecord (>= 4.2, < 7.2)
+    globalize (7.1.3)
+      activemodel (>= 7.0, < 8.2)
+      activerecord (>= 7.0, < 8.2)
+      activesupport (>= 7.0, < 8.2)
       request_store (~> 1.0)
     hashdiff (1.2.1)
     hashie (3.5.7)
@@ -348,7 +349,7 @@ GEM
       pusher-signature (~> 0.1.8)
     pusher-signature (0.1.8)
     racc (1.8.1)
-    rack (2.2.21)
+    rack (2.2.24)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-session (1.0.2)
@@ -399,7 +400,7 @@ GEM
     regexp_parser (2.9.0)
     reline (0.6.3)
       io-console (~> 0.5)
-    request_store (1.5.0)
+    request_store (1.7.0)
       rack (>= 1.4)
     require_all (3.0.0)
     responders (3.2.0)
@@ -488,7 +489,7 @@ GEM
       coercible (~> 1.0)
     thor (1.4.0)
     thread_safe (0.3.6)
-    timeout (0.4.4)
+    timeout (0.6.1)
     tomorrowio_rb (0.0.3)
     tsort (0.2.0)
     tzinfo (2.0.6)
@@ -540,7 +541,7 @@ DEPENDENCIES
   ffaker
   foreman
   geocoder
-  globalize
+  globalize (~> 7.1)
   kaminari-actionview
   kaminari-mongoid
   letter_opener

--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -1,11 +1,5 @@
 #!/usr/bin/env puma
 
-# Load "path" as a rackup file.
-#
-# The default is "config.ru".
-#
-rackup DefaultRackup
-
 port Integer(ENV.fetch("PORT") { 3000 })
 environment ENV.fetch("RACK_ENV") { "development" }
 


### PR DESCRIPTION
Unblocks the Rails 7.2 bump. Part of the Ruby/Rails upgrade sequence — this is PR 3, following the upgrade-prep PR (#889) and the Mongoid 9 PR (#892).

Rails stays on 7.1.5.2 here. Both gems support the 7.1 we are on today *and* the 8.x we are heading for, so landing them on 7.1 keeps them off the critical path of the Rails bump, where a failure would be ambiguous.

## Globalize 6.3.0 → 7.1.3

`globalize` 6.3.0 declares `activemodel/activerecord >= 4.2, < 7.2`, one of the two resolution-level blockers for Rails 7.2. 7.1.3 widens that to `>= 7.0, < 8.2`.

The surface is wider than the five `translates` calls it looks like, so behaviour was checked against both versions in turn rather than assumed. The output is byte-identical across:

- `translates` readers/writers, including the multi-attribute `Food` case
- per-locale writes and reads via `I18n.with_locale`
- `Model::Translation` constants and the explicit `has_many :*_translations`
- `with_translations` (`app/models/search.rb`), including chained after `accessible_by`, which is how `Search#resources` actually calls it
- `joins(:*_translations).where(locale:).pluck` (`app/jobs/data_export_job.rb`)
- the raw SQL join on `food_translations` in `Food.fts`
- reads in a locale with no translation row

## Puma 5.6.8 → 6.6.1

Puma 5 is end-of-life. Not required by Rails, but the Gemfile pinned it to an exact 5.6.8 and it has to move eventually; doing it here keeps it off the Rails PR.

Puma 6.0 removed the configuration constants, so `rackup DefaultRackup` in `config/puma.rb` raised at boot:

```
config/puma.rb:7:in `_load_from':
  uninitialized constant Puma::DSL::DefaultRackup (NameError)
```

**Worth a reviewer's attention: the specs cannot catch this.** `config/puma.rb` is only read when the server boots, and both the Dockerfile `CMD` and the Procfile `web` process start Puma with `-C config/puma.rb` — so this would have passed CI and failed on deploy.

Dropped the line rather than replacing it: Puma 6 already defaults `:rackup` to `config.ru` (`configuration.rb:157`) and `backend/config.ru` is present, so the directive only restated the default.

Verified by booting the real config, not just reading it:

- single mode: boots, serves `/api/conditions` (401 from Devise, as expected)
- cluster mode (`WEB_CONCURRENCY=2`): preloads, both workers boot, requests served across them — this is the path that actually runs the `before_fork` and `on_worker_boot` hooks
- both stores work after fork: Postgres (`sql.active_record` and `instantiation.active_record` in `Server-Timing` on a 200) and Mongo (a Mongoid read via `comments#index` returns 200)

Left the `before_fork`/`on_worker_boot` hooks alone. Modern Rails largely handles that itself, but trimming them changes production fork behaviour and is a separate concern from the version bump.

The rest of the 6.0 breaking-change list does not affect us: the `PUMA_` env var prefixing is irrelevant because `config/puma.rb` reads `PORT`, `MAX_THREADS` and `WEB_CONCURRENCY` itself via `ENV.fetch`, and the `remote_addr` change is irrelevant because nothing in `app/`, `config/` or `lib/` uses `remote_ip`/`remote_addr`.

## Lockfile

Transitive: `request_store` 1.5.0 → 1.7.0, `rack` 2.2.21 → 2.2.24 (patch — still Rack 2, `omniauth` 1.9.2 caps it below 3), `nio4r` and `timeout` patch bumps.

## Verification

- 320 examples, 0 failures
- `standardrb` clean, `erblint --lint-all` clean

## Note: a pre-existing flake, not from this PR

A full-suite run hit `spec/services/collection_retriever_spec.rb:54`:

```
expect(min_occurrence).to be < max_occurrence
  expected: < 2
       got:   2
```

The spec builds 5 check-ins from `object_ids.sample(5)` over 20 objects and asserts the top-10 occurrence counts have a spread; when ten objects tie at 2, it fails. **master fails 2/100 runs with the identical assertion and identical values** (this branch: 1/30 — the same rate). The randomness is `Array#sample`, which no gem version affects. Flagging it because CI will trip on it occasionally; it deserves its own issue rather than a fix smuggled in here.

## Merging

Please **rebase-and-merge or use a real merge commit — not squash.** The two commits are the unit of revert; squashing collapses that granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)