### PR TITLE
Make CollectionRetriever most_popular fixtures deterministic

### DIFF
--- a/backend/spec/services/collection_retriever_spec.rb
+++ b/backend/spec/services/collection_retriever_spec.rb
@@ -24,9 +24,19 @@ describe CollectionRetriever do
         let(:objects) { create_list(model_slug, 20) }
         let(:object_ids) { objects.map(&:id) }
 
+        # Nested slices give every object a known occurrence count. The first 2
+        # objects land in all five check-ins, the next 3 in four of them, and so
+        # on, so the counts run:
+        #
+        #   5 5 | 4 4 4 | 3 3 3 3 3 || 2 2 2 2 2 | 1 1 1 1 1
+        #
+        # The top ten therefore have a real spread (5 down to 3), and the tenth
+        # and eleventh differ (3 vs 2), so the `$limit 10` in
+        # CollectionRetriever#most_popular never has to break a tie at the
+        # cut-off. `object_ids.sample(5)` left both of those to chance.
         before do
-          5.times do
-            create(:checkin, ids_key => object_ids.sample(5))
+          [20, 15, 10, 5, 2].each do |size|
+            create(:checkin, ids_key => object_ids.first(size))
           end
         end
 
@@ -49,9 +59,11 @@ describe CollectionRetriever do
 
         it "makes occurrences counts available after retrieve" do
           subject.retrieve
-          max_occurrence = subject.occurrences.to_a.first["count"]
-          min_occurrence = subject.occurrences.to_a.last["count"]
-          expect(min_occurrence).to be < max_occurrence
+
+          # Which objects tie at a given count is not defined -- the aggregation
+          # sorts on count alone -- but the counts themselves are.
+          expect(subject.occurrences.map { |o| o["count"] }).to eq [5, 5, 4, 4, 4, 3, 3, 3, 3, 3]
+
           subject.occurrences.each do |o|
             expected_count = occurrences_for(o["_id"], ids_key)
             expect(o["count"]).to eq expected_count


### PR DESCRIPTION
Fixes #903.

## The flake

```
CollectionRetriever Tag most_popular makes occurrences counts available after retrieve
  Failure/Error: expect(min_occurrence).to be < max_occurrence

    expected: < 2
         got:   2
```

The setup built five check-ins from `object_ids.sample(5)` over 20 objects — 25 random draws — then asserted the returned counts had a **strict** spread. `CollectionRetriever#most_popular` caps `occurrences` at ten (`{"$limit" => 10}`), so whenever the ten highest-counted objects tie, `min == max` and the assertion fails. With only 25 draws over 20 objects that is an ordinary outcome.

Nothing version-specific: the randomness is plain `Array#sample`, and `.rspec` sets no random ordering.

## The fix

Nested slices instead of a random sample, giving every object a known count:

```ruby
[20, 15, 10, 5, 2].each do |size|
  create(:checkin, ids_key => object_ids.first(size))
end
```

```
5 5 | 4 4 4 | 3 3 3 3 3 || 2 2 2 2 2 | 1 1 1 1 1
```

This removes **two** sources of nondeterminism, not just the visible one:

1. The top ten now have a real spread (5 down to 3), so `min < max` holds by construction.
2. The tenth and eleventh objects differ (3 vs 2), so the `$limit 10` never has to break a tie at the cut-off. A tie spanning that boundary would make *which* objects come back arbitrary, which could flake `retrieves the most popular` in exactly the same way. That one had not been observed failing, but it was exposed to the same root cause.

Because the counts are now known, the weak `min < max` check is replaced with the exact sequence:

```ruby
expect(subject.occurrences.map { |o| o["count"] }).to eq [5, 5, 4, 4, 4, 3, 3, 3, 3, 3]
```

That asserts strictly more than before — the descending sort *and* the counts, rather than merely that a spread exists. Which objects tie at a given count is still undefined, since the aggregation sorts on count alone, so the assertion deliberately covers counts only.

The sibling examples still hold and are now deterministic too: objects outside the top ten have counts 2 and 1 against a minimum of 3, and all twenty objects are global, so `limits results to 10` always finds ten.

## Verification

| | Runs | Failures |
| --- | --- | --- |
| `master` | 500 | **5** (all this flake) |
| this branch | 300 | **0** |

Full suite green (320 examples, 0 failures), `standardrb` clean.

<details>
<summary>One measurement note, in case anyone repeats this</summary>

An earlier verification run on this branch showed 3 unrelated failures (`limits results to 10`, and a `create_profile!` error in the `most_recent` block). Those were an artefact of my own measurement, not the change: I had a full `rspec spec` running concurrently against the same databases, and `spec/support/db_cleaner.rb` does `DatabaseCleaner[:active_record].clean_with(:truncation)` in `before(:suite)` — which truncated `foods`/`tags` out from under the loop. The failures landed on runs 2–4, exactly during the overlap. Re-run with nothing else touching the databases: 0/300. Worth knowing that these suites cannot be run in parallel against one database.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)