### PR TITLE
Fix notification read and dismiss under Mongoid 9

### DIFF
--- a/backend/app/controllers/api/v1/notifications_controller.rb
+++ b/backend/app/controllers/api/v1/notifications_controller.rb
@@ -2,7 +2,11 @@ module Api
   module V1
     class NotificationsController < ApplicationController
       def index
-        notifications = Notification.where(encrypted_notify_user_id: current_user.encrypted_id)
+        # The aggregation reaches through `notificateable` to title each group, so without
+        # eager loading this is one query per notification.
+        notifications = Notification
+          .where(encrypted_notify_user_id: current_user.encrypted_id)
+          .includes(:notificateable)
 
         authorize_collection :index, notifications
 
@@ -41,7 +45,9 @@ module Api
         parameters[:notificateable_type] = parameters[:notificateable_type].titleize
         parameters[:encrypted_notify_user_id] = current_user.encrypted_id
 
-        parameters
+        # Mongoid 9 requires a query expression to be a Hash and raises InvalidQuery on
+        # an ActionController::Parameters, which Mongoid 8 accepted.
+        parameters.to_h
       end
 
       def authorize_collection(name, collection)

--- a/backend/app/models/notification.rb
+++ b/backend/app/models/notification.rb
@@ -3,7 +3,11 @@ class Notification
   include Mongoid::Timestamps
   include Usernameable
 
-  after_initialize :set_defaults
+  # Only derive post_id when it is not already stored. This runs on every instantiation,
+  # including records loaded from the database, and it reaches through `notificateable`,
+  # so without the guard every Notification loaded costs an extra query to recompute a
+  # value it was already holding.
+  after_initialize :set_defaults, if: -> { post_id.blank? }
 
   field :kind, type: String
   field :encrypted_user_id, type: String, encrypted: {type: :integer}

--- a/backend/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::NotificationsController do
+  let(:user) { create(:user) }
+  let(:notifier) { create(:user) }
+  let(:notified_post) { create(:post, encrypted_user_id: user.encrypted_id) }
+
+  let!(:notification) do
+    create(:notification,
+      kind: "comment",
+      notificateable: notified_post,
+      encrypted_user_id: notifier.encrypted_id,
+      encrypted_notify_user_id: user.encrypted_id)
+  end
+
+  before { sign_in user }
+
+  describe "index" do
+    it "returns the signed-in user's notifications grouped by kind and subject" do
+      get :index
+
+      expect(response).to have_http_status :ok
+      expect(response_body[:notifications].size).to eq 1
+      expect(response_body[:notifications].first[:kind]).to eq "comment"
+      expect(response_body[:notifications].first[:count]).to eq 1
+    end
+
+    it "collapses repeated notifications on the same subject into a count" do
+      create(:notification,
+        kind: "comment",
+        notificateable: notified_post,
+        encrypted_user_id: create(:user).encrypted_id,
+        encrypted_notify_user_id: user.encrypted_id)
+
+      get :index
+
+      expect(response_body[:notifications].size).to eq 1
+      expect(response_body[:notifications].first[:count]).to eq 2
+    end
+
+    it "does not return notifications addressed to somebody else" do
+      create(:notification,
+        kind: "reaction",
+        notificateable: create(:post),
+        encrypted_notify_user_id: create(:user).encrypted_id)
+
+      get :index
+
+      expect(response_body[:notifications].map { |n| n[:kind] }).to eq ["comment"]
+    end
+  end
+
+  describe "update" do
+    let(:subject_params) do
+      {notificateable_id: notified_post.id.to_s, notificateable_type: "post"}
+    end
+
+    it "marks the notifications for that subject as read" do
+      put :update, params: subject_params
+
+      expect(response).to have_http_status :ok
+      expect(notification.reload.unread).to be false
+    end
+
+    it "returns the regrouped notifications" do
+      put :update, params: subject_params
+
+      expect(response_body[:notifications].first[:unread]).to be false
+    end
+
+    it "leaves another user's notifications on the same subject alone" do
+      theirs = create(:notification,
+        kind: "comment",
+        notificateable: notified_post,
+        encrypted_notify_user_id: create(:user).encrypted_id)
+
+      put :update, params: subject_params
+
+      expect(theirs.reload.unread).to be true
+    end
+  end
+
+  describe "destroy" do
+    it "removes the notifications for that subject" do
+      expect {
+        delete :destroy, params: {
+          notificateable_id: notified_post.id.to_s,
+          notificateable_type: "post"
+        }
+      }.to change { Notification.count }.by(-1)
+
+      expect(response).to have_http_status :no_content
+    end
+  end
+end


### PR DESCRIPTION
Fixes #908.

Marking a notification as read and dismissing one both raise on every request on `master` today. This is a regression from the Mongoid 8 → 9 upgrade in #892, not something waiting on the rest of the upgrade work, so it is worth taking on its own rather than behind anything else.

Two commits: the fix, then the spec that guards it.

## The regression

`NotificationsController#notification_params` returns `ActionController::Parameters`, and `update` and `destroy` feed it straight into `Notification.where(...)`. `Parameters` has not been a `Hash` since Rails 5; Mongoid 8 accepted it, Mongoid 9 requires a real Hash and raises:

```
Mongoid::Errors::InvalidQuery: Expression must be a Hash:
  #<ActionController::Parameters {"notificateable_id"=>"...", "notificateable_type"=>"Post", ...}>
```

In production `ExceptionLogger`'s `rescue_from "Exception"` turns that into a 422 quoting a Mongoid internal error, which is likely why it has read as noise rather than as two broken endpoints. `index` is unaffected — it builds its own criteria.

The fix is `to_h`, which is safe because the parameters have already been through `permit`.

**I audited `app/` and `lib/` for the same shape and this is the only Mongoid case.** The others are Active Record or Active Model, which still accept permitted `Parameters`, or plain hashes built by hand — `ReactionsController#reaction_params` is the latter.

## Two N+1s in the same controller

Not scope creep: `config/environments/test.rb` sets `Bullet.raise = true`, so these made the endpoint **untestable**. Any spec touching `index` died on `UnoptimizedQueryError` before reaching an assertion. Fixing them is what allowed the regression spec to exist at all.

- `Notification`'s `after_initialize :set_defaults` recomputed `post_id` by reaching through `notificateable` on *every* instantiation — including records read back from the database that already had the value stored. One extra query per notification loaded, anywhere in the app, to recompute something it was already holding. Now guarded on `post_id.blank?`, which still backfills documents written before the field existed while costing nothing for the rest.
- The `index` aggregation titles each group through `notificateable`, so the query now eager loads it. Mongoid 9 does support `includes` for this polymorphic `belongs_to`; I checked before relying on it rather than assuming.

## Verification

- **331 examples, 0 failures** on this branch (324 on `master`, plus the 7 new ones), `standardrb` clean
- Reverting just the fix commit and re-running the new spec reproduces the bug: 5 failures, `Mongoid::Errors::InvalidQuery` on `update` and `destroy`, `Bullet::Notification::UnoptimizedQueryError` on `index`
- Branched from `master`, so it carries none of the in-flight upgrade work

## Note on overlap

These same two commits also appear on the branch for #912, which is where they were found. They are cherry-picked here so this can merge first without waiting on that much larger review. Once this lands, #912 rebases and git drops the duplicates automatically.

Please **rebase-and-merge or use a real merge commit — not squash**, so the fix stays separable from its spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

